### PR TITLE
Fix link to GTK theme in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 
 #### System
 
--   [GTK](https://github.com/catppuccin/xresources) (WIP)
+-   [GTK](https://github.com/catppuccin/gtk) (WIP)
 -   [Xresources](https://github.com/catppuccin/xresources)
 -   [Cava](https://github.com/catppuccin/cava)
 


### PR DESCRIPTION
This is a typo-level change. Thanks for the cool theme!