### PR TITLE
fix: use main branch for assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <h3 align="center">
-	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/dev/assets/logos/exports/1544x1544_circle.png" width="100" alt="Logo"/><br/>
-	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/dev/assets/misc/transparent.png" height="30" width="0px"/>
+	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/logos/exports/1544x1544_circle.png" width="100" alt="Logo"/><br/>
+	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
 	Catppuccin Theme
-	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/dev/assets/misc/transparent.png" height="30" width="0px"/>
+	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
 </h3>
 
 <h6 align="center">
@@ -980,6 +980,6 @@ Thanks to the following tools developing this project is possible:
 
 &nbsp;
 
-<p align="center"><img src="https://raw.githubusercontent.com/catppuccin/catppuccin/dev/assets/footers/gray0_ctp_on_line.svg?sanitize=true" /></p>
+<p align="center"><img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/footers/gray0_ctp_on_line.svg?sanitize=true" /></p>
 <p align="center">Copyright &copy; 2021-present <a href="https://github.com/catppuccin" target="_blank">Catppuccin Org</a>
 <p align="center"><a href="https://github.com/catppuccin/catppuccin/blob/main/LICENSE"><img src="https://img.shields.io/static/v1.svg?style=for-the-badge&label=License&message=MIT&logoColor=d9e0ee&colorA=302d41&colorB=c9cbff"/></a></p>

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ Catppuccin is a community-driven pastel theme that aims to be the middle ground 
 &nbsp;
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/dev/assets/palette/demo.png" alt="catppuccin infrastructure"/>
+<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/palette/demo.png" alt="catppuccin infrastructure"/>
 </p>
 
 &nbsp;
@@ -27,6 +27,6 @@ Catppuccin is a community-driven pastel theme that aims to be the middle ground 
 
 &nbsp;
 
-<p align="center"><img src="https://raw.githubusercontent.com/catppuccin/catppuccin/dev/assets/footers/gray0_ctp_on_line.svg?sanitize=true" /></p>
+<p align="center"><img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/footers/gray0_ctp_on_line.svg?sanitize=true" /></p>
 <p align="center">Copyright &copy; 2021-present <a href="https://github.com/catppuccin" target="_blank">Catppuccin Org</a>
 <p align="center"><a href="https://github.com/catppuccin/catppuccin/blob/main/LICENSE"><img src="https://img.shields.io/static/v1.svg?style=for-the-badge&label=License&message=MIT&logoColor=d9e0ee&colorA=302d41&colorB=c9cbff"/></a></p>

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -23,5 +23,5 @@ Every palette consits of two subpalettes: one monochromatic and one analogous. T
 ### Catppuccin Infrastructure
 
 <p align="center">
-<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/dev/assets/palette/infrastructure.png" alt="catppuccin infrastructure"/>
+<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/palette/infrastructure.png" alt="catppuccin infrastructure"/>
 </p>


### PR DESCRIPTION
the assets also work without this change but in future this change will
eventually be required, when some assets are changed while the features
(or colors or whatever) are still in the dev branch only: this would
result in assets from the dev branch conflicting with the content of the
main branch

Signed-off-by: brvn0 <me@brvn0.de>