### PR TITLE
docs(README): add showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
   ·
   <a href="https://github.com/catppuccin/catppuccin#-ports-and-more">Ports</a>
   ·
+  <a href="https://github.com/catppuccin/catppuccin#-showcase">Showcase</a>
+  ·
   <a href="https://github.com/catppuccin/catppuccin/tree/main/docs">Docs</a>
 </h6>
 
@@ -1065,6 +1067,15 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 - [Thunderbird](https://github.com/catppuccin/thunderbird)
 - [YouTube](https://github.com/catppuccin/youtube)
 </details>
+
+&nbsp;
+
+### 🌟 Showcase
+
+If you're making an application or tool using our palette, please let us know by adding it below!
+
+- 🌟 [flotes.app](https://flotes.app/) - a free note-taking app enhanced with flashcard features
+- 🌟 [name] - [short description]
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,10 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 
 ### 🌟 Showcase
 
+> **Note** <br>
+> Catppuccin staff reserve the right to remove and reject showcase additions if we determine the addition to be in
+> violation of our [CODE OF CONDUCT](https://github.com/catppuccin/.github/blob/main/CODE_OF_CONDUCT.md).
+
 If you're making an application or tool using our palette, please let us know by adding it below!
 
 - 🌟 [flotes.app](https://flotes.app/) - a free note-taking app enhanced with flashcard features


### PR DESCRIPTION
As requested by some members of the community, this PR adds a showcase section to the main README. 

Catppuccin is all about community and the @catppuccin/staff agree that it's a great idea to host a place on our docs to showcase the lovely applications and tools that people are creating with our palette, outside of the amazing ports.

I've included an initial entry from @Everduin94 with their app as they previously mentioned this idea on our discord. (Hope that's okay!)