### PR TITLE
feat: add ports.yml schema & add info to conform to the schema

### DIFF
--- a/resources/ports.schema.json
+++ b/resources/ports.schema.json
@@ -1,0 +1,116 @@
+{
+    "definitions": {},
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/catppuccin/catppuccin/main/resources/ports.schema.json",
+    "type": "object",
+    "additionalProperties": false,
+    "patternProperties": {
+        "[A-Za-z0-9_\\-]": {
+            "$id": "#ports/port",
+            "title": "Port",
+            "type": "object",
+            "description": "The GitHub repository name of the port.",
+            "examples": ["nvim"],
+            "required": ["category", "name", "platform"],
+            "properties": {
+                "name": {
+                    "$id": "#ports/port/name",
+                    "title": "Name",
+                    "description": "The Name of the software the port is for",
+                    "type": "string",
+                    "examples": ["Neovim"]
+                },
+                "category": {
+                    "$id": "#ports/port/category",
+                    "title": "Category",
+                    "type": "string",
+                    "enum": [
+                        "browser",
+                        "browser_extension",
+                        "cli",
+                        "code_editor",
+                        "development",
+                        "leisure",
+                        "library",
+                        "messaging",
+                        "note_taking",
+                        "productivity",
+                        "search_engine",
+                        "social",
+                        "system",
+                        "terminal"
+                    ],
+                    "examples": ["editor"]
+                },
+                "platform": {
+                    "$id": "#ports/port/platform",
+                    "title": "Platform",
+                    "description": "The platforms the port supports. Either an array of supported operating systems, \"agnostic\" (indicating support for all platforms), or \"userstyle\".",
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "$id": "#ports/port/platform/os",
+                                "title": "Operating Systems",
+                                "type": "string",
+                                "enum": [
+                                    "android",
+                                    "ios",
+                                    "linux",
+                                    "macos",
+                                    "windows"
+                                ],
+                                "examples": [
+                                    ["linux", "macos", "windows"],
+                                    ["android", "ios"]
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "enum": ["agnostic", "userstyle"]
+                        }
+                    ]
+                },
+                "color": {
+                    "$id": "#ports/port/color",
+                    "title": "Color",
+                    "description": "The fill color for the icon on the website",
+                    "type": "string",
+                    "enum": [
+                        "rosewater",
+                        "flamingo",
+                        "pink",
+                        "mauve",
+                        "red",
+                        "maroon",
+                        "peach",
+                        "yellow",
+                        "green",
+                        "teal",
+                        "sky",
+                        "sapphire",
+                        "blue",
+                        "lavender",
+                        "text"
+                    ],
+                    "examples": ["pink"]
+                },
+                "icon": {
+                    "$id": "#ports/port/icon",
+                    "title": "Icon",
+                    "description": "The icon to use on the website. This should be the same name as the SVG file on https://simpleicons.org/. If a `.svg` suffix is present, it's taken from the local website repository resources.",
+                    "type": "string",
+                    "examples": ["neovim", "neovim.svg"]
+                },
+                "userstyle": {
+                    "$id": "#ports/port/userstyle",
+                    "title": "Userstyle",
+                    "description": "Whether the port is a userstyle",
+                    "type": "boolean",
+                    "examples": [true]
+                }
+            }
+        }
+    }
+}

--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -1,412 +1,820 @@
 alacritty:
+    name: Alacritty
+    category: terminal
     color: peach
-    os: [linux, macos, windows]
+    platform: [linux, macos, windows]
 alfred:
+    name: Alfred
+    category: productivity
     color: mauve
-    os: [macos]
+    platform: [macos]
 aliucord:
-    os: [android]
+    name: Aliucord
+    category: messaging
+    platform: [android]
 amfora:
-    os: [linux, macos, windows]
+    name: Amfora
+    category: leisure
+    platform: [linux, macos, windows]
 anilist:
+    name: AniList
+    category: leisure
+    platform: userstyle
     color: blue
 anki:
+    name: Anki
+    category: productivity
+    platform: agnostic
     icon: anki.svg
     color: blue
 base16:
+    name: Base16
+    category: system
+    platform: agnostic
 bat:
+    name: bat
+    category: cli
+    platform: [linux, macos, windows]
     icon: bat.svg
-    os: [linux, macos, windows]
 bento:
+    name: Bento
+    category: productivity
+    platform: agnostic
 binary-ninja:
-    os: [linux, macos, windows]
+    name: Binary Ninja
+    category: code_editor
+    platform: [linux, macos, windows]
 bitburner:
-    os: [linux, macos, windows]
+    name: BitBurner
+    category: leisure
+    platform: [linux, macos, windows]
 blackbox:
-    os: [linux]
+    name: Black Box
+    category: terminal
+    platform: [linux]
 blink:
-    os: [ios]
+    name: Blink
+    category: terminal
+    platform: [ios]
 blockbench:
-    os: [linux, macos, windows]
+    name: Blockbench
+    category: leisure
+    platform: [linux, macos, windows]
 bottom:
-    os: [linux, macos, windows]
+    name: bottom
+    category: cli
+    platform: [linux, macos, windows]
 brave-search:
+    name: Brave Search
+    category: productivity
+    platform: userstyle
     icon: brave
     color: peach
 btop:
-    os: [linux, macos]
+    name: Btop++
+    category: cli
+    platform: [linux, macos]
 cava:
-    os: [linux, macos]
+    name: C.A.V.A.
+    category: cli
+    platform: [linux, macos]
 chrome:
+    name: Google Chrome
+    category: browser
+    platform: [linux, macos, windows]
     icon: googlechrome
     color: yellow
-    os: [linux, macos, windows]
 cinny:
-    os: [linux]
+    name: Cinny
+    category: messaging
+    platform: [linux]
 codeberg:
+    name: Codeberg
+    category: productivity
+    platform: userstyle
 codemirror:
+    name: CodeMirror
+    category: development
+    platform: agnostic
 conky:
-    os: [linux]
+    name: Conky
+    category: system
+    platform: [linux]
 contour:
-    os: [linux, macos, windows]
+    name: Contour
+    category: terminal
+    platform: [linux, macos, windows]
 crt:
-    os: [linux, macos]
+    name: 'CRT: cool-retro-term'
+    category: terminal
+    platform: [linux, macos]
 cursors:
+    name: Cursors
+    category: system
+    platform: [linux]
     icon: cursors.svg
-    os: [linux]
 cutter:
-    os: [linux, macos, windows]
+    name: Cutter
+    category: code_editor
+    platform: [linux, macos, windows]
 dark-reader:
+    name: Dark Reader
+    category: browser_extension
+    platform: agnostic
     icon: darkreader
     color: red
 deepl:
+    name: DeepL
+    category: productivity
+    platform: userstyle
 discord:
+    name: Discord
+    category: messaging
+    platform: [linux, macos, windows]
     color: blue
-    os: [linux, macos, windows]
 dmenu:
-    os: [linux]
+    name: dmenu
+    category: system
+    platform: [linux]
 duckduckgo:
+    name: DuckDuckGo
+    category: productivity
+    platform: userstyle
     color: peach
 dunst:
-    os: [linux]
+    name: Dunst
+    category: system
+    platform: [linux]
 dwarf-fortress:
-    os: [linux, macos, windows]
+    name: Dwarf Fortress
+    category: leisure
+    platform: [linux, macos, windows]
 element:
-    os: [linux, macos, windows]
+    name: Element
+    category: leisure
+    platform: [linux, macos, windows]
 elk:
+    name: Elk
+    category: social
+    platform: agnostic
 emacs:
+    name: Emacs
+    category: code_editor
+    platform: [linux, macos, windows]
     icon: gnuemacs
     color: mauve
-    os: [linux, macos, windows]
 enmity:
-    os: [ios]
+    name: Enmity
+    category: messaging
+    platform: [ios]
 fcitx5:
-    os: [linux]
+    name: fcitx5
+    category: system
+    platform: [linux]
 firefox:
+    name: Firefox
+    category: browser
+    platform: [linux, macos, windows]
     color: red
-    os: [linux, macos, windows]
 fish:
+    name: Fish
+    category: cli
+    platform: [linux, macos]
     icon: fish.svg
     color: green
-    os: [linux, macos]
 floris-board:
-    os: [android]
+    name: FlorisBoard
+    category: system
+    platform: [android]
 foliate:
-    os: [linux]
+    name: Foliate
+    category: productivity
+    platform: [linux]
 foot:
-    os: [linux]
+    name: foot
+    category: terminal
+    platform: [linux]
 fzf:
-    os: [linux, macos]
+    name: fzf
+    category: cli
+    platform: [linux, macos]
 geany:
-    os: [linux]
+    name: Geany
+    category: code_editor
+    platform: [linux]
 gedit:
-    os: [linux]
+    name: Gedit
+    category: code_editor
+    platform: [linux]
 github:
+    name: GitHub
+    category: productivity
+    platform: userstyle
     color: text
 github-readme-stats:
+    name: GitHub Readme Stats
+    category: social
+    platform: agnostic
     color: text
 github-readme-tech-stack:
+    name: GitHub Readme Tech Stack
+    category: social
+    platform: agnostic
     color: text
 gitui:
+    name: GitUI
+    category: cli
+    platform: [linux, macos]
     icon: gitui.svg
-    os: [linux, macos]
 glamour:
-    os: [linux, macos]
+    name: Glamour
+    category: cli
+    platform: [linux, macos]
 gnome-terminal:
+    name: GNOME Terminal
+    category: terminal
+    platform: [linux]
     color: text
     icon: gnometerminal
 go:
+    name: Go
+    category: library
+    platform: agnostic
 grub:
+    name: GRUB
+    category: system
+    platform: [linux]
     icon: gnu
     color: text
-    os: [linux]
 gtk:
+    name: GTK
+    category: system
+    platform: [linux]
     color: green
-    os: [linux]
 hacker-news:
+    name: Hacker News
+    category: social
+    platform: userstyle
     icon: ycombinator
 helix:
-    os: [linux, macos, windows]
+    name: Helix
+    category: code_editor
+    platform: [linux, macos, windows]
 hexchat:
+    name: HexChat
+    category: messaging
+    platform: [linux, windows]
     icon: hexchat.svg
     color: peach
-    os: [linux, windows]
 highlightjs:
+    name: Highlight.js
+    category: development
+    platform: agnostic
 home-assistant:
+    name: Home Assistant
+    category: leisure
+    platform: agnostic
     icon: homeassistant
 hyper:
+    name: Hyper
+    category: terminal
+    platform: [linux, macos, windows]
     color: text
-    os: [linux, macos, windows]
 hyprland:
-    os: [linux]
+    name: Hyprland
+    category: system
+    platform: [linux]
 i3:
+    name: i3/sway
+    category: system
+    platform: [linux]
     color: text
     icon: i3wm.svg
-    os: [linux]
 ichi.moe:
+    name: ichi.moe
+    category: productivity
+    platform: userstyle
 infinity:
+    name: Infinity for Reddit
+    category: social
+    platform: [android]
     icon: reddit
     color: peach
 insomnia:
+    name: Insomnia
+    category: development
+    platform: [android]
     color: blue
-    os: [android]
 invidious:
+    name: Invidious
+    category: social
+    platform: userstyle
     icon: youtube
     color: red
 iterm:
+    name: iTerm2
+    category: terminal
+    platform: [macos]
     icon: iterm2
     color: green
-    os: [macos]
 jetbrains:
+    name: JetBrains
+    category: code_editor
+    platform: [linux, macos, windows]
     color: text
-    os: [linux, macos, windows]
 joplin:
+    name: joplin
+    category: note_taking
+    platform: [linux, macos, windows]
     color: blue
-    os: [linux, macos, windows]
 k9s:
+    name: k9s
+    category: cli
+    platform: [linux, macos]
     icon: kubernetes
     color: blue
-    os: [linux, macos]
 Kvantum:
-    os: [linux]
+    name: Kvantum
+    category: system
+    platform: [linux]
 kakoune:
-    os: [linux, macos]
+    name: Kakoune
+    category: code_editor
+    platform: [linux, macos]
 kde:
+    name: KDE
+    category: system
+    platform: [linux]
     color: blue
-    os: [linux]
 kitty:
+    name: Kitty
+    category: terminal
+    platform: [linux, macos]
     icon: kitty.svg
     color: green
-    os: [linux, macos]
 konsole:
+    name: Konsole
+    category: terminal
+    platform: [linux]
     icon: kde
     color: blue
-    os: [linux]
 lapce:
-    os: [linux, macos, windows]
+    name: Lapce
+    category: code_editor
+    platform: [linux, macos, windows]
 lastfm:
+    name: Last.fm
+    category: leisure
+    platform: userstyle
     icon: lastdotfm
     color: red
 lazygit:
+    name: Lazygit
+    category: cli
+    platform: [linux, macos]
     color: green
 libreddit:
+    name: Libreddit
+    category: social
+    platform: userstyle
     icon: reddit
     color: peach
 lxqt:
+    name: LxQT
+    category: system
+    platform: [linux]
     icon: lxqt.svg
     color: sky
-    os: [linux]
 mailspring:
-    os: [linux, macos, windows]
+    name: Mailspring
+    category: productivity
+    platform: [linux, macos, windows]
 mako:
-    os: [linux]
+    name: Mako
+    category: system
+    platform: [linux]
 mastodon:
+    name: Mastodon
+    category: social
+    platform: userstyle
 mattermost:
+    name: Mattermost
+    category: messaging
+    platform: agnostic
 mc:
-    os: [linux, macos]
+    name: Midning Commander
+    category: cli
+    platform: [linux, macos]
 mdBook:
+    name: mdBook
+    category: development
+    platform: agnostic
     icon: mdbook
 micro:
+    name: Micro
+    category: code_editor
+    platform: [linux, macos, windows]
     icon: micro.svg
-    os: [linux, macos, windows]
 minecraft:
-    os: [linux, macos, windows]
+    name: Minecraft
+    category: leisure
+    platform: [linux, macos, windows]
 modrinth:
+    name: Modrinth
+    category: leisure
+    platform: userstyle
     color: green
 monkeytype:
+    name: monkeytype
+    category: leisure
+    platform: userstyle
     icon: monkeytype.svg
     color: text
 neomutt:
-    os: [linux, macos]
+    name: NeoMutt
+    category: cli
+    platform: [linux, macos]
 newsboat:
-    os: [linux, macos]
+    name: Newsboat
+    category: cli
+    platform: [linux, macos]
 nighttab:
+    name: Nighttab
+    category: browser_extension
+    platform: agnostic
 nitter:
+    name: Nitter
+    category: social
+    platform: userstyle
     icon: twitter
     color: blue
 noir:
-    os: [ios]
+    name: Noir
+    category: browser_extension
+    platform: [ios]
 notepad-plus-plus:
+    name: Notepad++
+    category: code_editor
+    platform: [windows]
     icon: notepadplusplus
     color: green
-    os: [windows]
 nova:
-    os: [macos]
+    name: Nova
+    category: code_editor
+    platform: [macos]
 nvim:
+    name: Neovim
+    category: code_editor
+    platform: [linux, macos, windows]
     icon: neovim
     color: green
-    os: [linux, macos, windows]
 obs:
+    name: OBS Studio
+    category: productivity
+    platform: [linux, macos, windows]
     icon: obsstudio
-    os: [linux, macos, windows]
 obsidian:
+    name: Obsidian
+    category: note_taking
+    platform: [linux, macos, windows]
     color: mauve
-    os: [linux, macos, windows]
 pantone:
+    name: Pantone
+    category: library
+    platform: agnostic
 papirus-folders:
+    name: Papirus Folders
+    category: system
+    platform: [linux]
     icon: folders.svg
-    os: [linux]
 plank:
-    os: [linux]
+    name: Plank
+    category: system
+    platform: [linux]
 plymouth:
-    os: [linux]
+    name: Plymouth
+    category: system
+    platform: [linux]
 polybar:
-    os: [linux]
+    name: Polybar
+    category: system
+    platform: [linux]
 prismlauncher:
-    os: [linux, macos, windows]
+    name: Prism Launcher
+    category: leisure
+    platform: [linux, macos, windows]
 proton:
+    name: Proton
+    category: productivity
+    platform: userstyle
     icon: protonmail
     color: lavender
 pyradio:
-    os: [linux, macos, windows]
+    name: PyRadio
+    category: leisure
+    platform: [linux, macos, windows]
 python:
+    name: Python
+    category: library
+    platform: agnostic
 qt5ct:
-    os: [linux]
+    name: qt5ct
+    category: system
+    platform: [linux]
 qutebrowser:
+    name: qutebrowser
+    category: browser
+    platform: [linux, macos, windows]
     icon: qutebrowser.svg
-    os: [linux, macos, windows]
 qterminal:
+    name: QTerminal
+    category: terminal
+    platform: [linux]
     icon: lxqt.svg
     color: sky
-    os: [linux]
 rboard:
+    name: Rboard
+    category: system
+    platform: [android]
     color: blue
     icon: gboard.svg
 regolith:
-    os: [linux]
+    name: Regolith Desktop
+    category: system
+    platform: [linux]
 remnote:
+    name: Remnote
+    category: note_taking
+    platform: agnostic
 revolt:
+    name: Revolt
+    category: messaging
+    platform: [linux, macos, windows]
     icon: revoltdotchat
-    os: [linux, macos, windows]
 rofi:
-    os: [linux]
+    name: Rofi
+    category: system
+    platform: [linux]
 rust:
+    name: Rust
+    category: library
+    platform: agnostic
 sc-im:
+    name: sc-im
+    category: cli
+    platform: [linux, macos]
 sddm:
-    os: [linux]
+    name: SDDM
+    category: system
+    platform: [linux]
 SearXNG:
+    name: SearXNG
+    category: search_engine
+    platform: userstyle
 sharex:
-    os: [windows]
+    name: ShareX
+    category: productivity
+    platform: [windows]
 sideberry:
+    name: Sideberry
+    category: browser_extension
+    platform: agnostic
 slack:
+    name: Slack
+    category: messaging
+    platform: agnostic
 spicetify:
+    name: Spicetify
+    category: leisure
+    platform: [linux, macos, windows]
     color: green
     icon: spotify
-    os: [linux, macos, windows]
 spotify-player:
+    name: spotify-player
+    category: leisure
+    platform: [linux, macos, windows]
     color: green
     icon: spotify
-    os: [linux, macos, windows]
 spotify-tui:
+    name: spotify-tui
+    category: leisure
+    platform: [linux, macos, windows]
     color: green
     icon: spotify
-    os: [linux, macos, windows]
 spyder:
+    name: spyder
+    category: code_editor
+    platform: [linux, macos, windows]
     icon: spyderide
     color: red
-    os: [linux, macos, windows]
 st:
-    os: [linux]
+    name: st
+    category: terminal
+    platform: [linux]
 stable-diffusion-web-ui:
-    os: [linux, macos, windows]
+    name: Stable Diffusion WebUI
+    category: leisure
+    platform: userstyle
 startpage:
+    name: Startpage
+    category: search_engine
+    platform: agnostic
 steam:
+    name: Steam
+    category: leisure
+    platform: [linux, macos, windows]
     color: blue
-    os: [linux, macos, windows]
 sublime-text:
+    name: Sublime Text
+    category: code_editor
+    platform: [linux, macos, windows]
     color: yellow
     icon: sublimetext
-    os: [linux, macos, windows]
 sumatra-pdf:
-    os: [windows]
+    name: SumatraPDF
+    category: productivity
+    platform: [windows]
 tabby:
-    os: [linux, macos, windows]
+    name: Tabby
+    category: terminal
+    platform: [linux, macos, windows]
 tailwindcss:
+    name: Tailwind CSS
+    category: development
+    platform: agnostic
     color: sky
 telegram:
+    name: Telegram
+    category: messaging
+    platform: agnostic
     color: blue
 terminator:
-    os: [linux]
+    name: Terminator
+    category: terminal
+    platform: [linux]
 Terminal.app:
-    os: [macos]
+    name: Terminal.app
+    category: terminal
+    platform: [macos]
 termux:
-    os: [android]
+    name: Termux
+    category: terminal
+    platform: [android]
 thelounge:
+    name: The Lounge
+    category: messaging
+    platform: agnostic
 thunderbird:
+    name: Thunderbird
+    category: productivity
+    platform: [linux, macos, windows]
     color: blue
-    os: [linux, macos, windows]
 tilix:
-    os: [linux]
+    name: Tilix
+    category: terminal
+    platform: [linux]
 tmux:
+    name: tmux
+    category: cli
+    platform: [linux, macos]
     color: green
-    os: [linux, macos]
 tty:
-    os: [linux]
-tym:
+    name: tty
+    category: system
+    platform: [linux]
 tutanota:
-  color: red
+    name: Tutanota
+    category: productivity
+    platform: userstyle
+    color: red
+tym:
+    name: tym
+    category: terminal
+    platform: [linux]
 ui:
+    name: UI
+    category: library
+    platform: agnostic
     icon: react
     color: sky
 ulauncher:
-    os: [linux]
+    name: Ulauncher
+    category: system
+    platform: [linux]
 unreal-engine:
+    name: Unreal Engine
+    category: development
+    platform: [linux, macos, windows]
     icon: unrealengine
     color: blue
-    os: [linux, macos, windows]
 urxvt:
-    os: [linux]
+    name: Urxvt
+    category: terminal
+    platform: [linux]
 vercel:
+    name: Vercel
+    category: development
+    platform: userstyle
 vim:
+    name: Vim
+    category: code_editor
+    platform: [linux, macos, windows]
     color: green
-    os: [linux, macos, windows]
 vimium:
+    name: Vimium
+    category: browser_extension
+    platform: agnostic
 visual-studio:
+    name: Visual Studio
+    category: code_editor
+    platform: [windows]
     icon: visualstudio
-    os: [windows]
 vivaldi:
+    name: Vivaldi
+    category: browser
+    platform: [linux, macos, windows]
     color: peach
 vscode:
+    name: Visual Studio Code
+    category: code_editor
+    platform: [linux, macos, windows]
     color: blue
     icon: visualstudiocode
-    os: [linux, macos, windows]
 warp:
-    os: [macos]
+    name: Warp
+    category: terminal
+    platform: [macos]
 waybar:
-    os: [linux]
+    name: waybar
+    category: system
+    platform: [linux]
 wezterm:
+    name: WezTerm
+    category: terminal
+    platform: [linux, macos, windows]
     icon: wezterm.svg
-    os: [linux, macos, windows]
 whoogle:
+    name: Whoogle
+    category: search_engine
+    platform: userstyle
 wikiwand:
+    name: WikiWand
+    category: productivity
+    platform: userstyle
     icon: wikipedia
 windows-files:
+    name: Windows Files
+    category: system
+    platform: [windows]
     icon: windows-files.svg
     color: yellow
-    os: [windows]
 windows-terminal:
+    name: Windows Terminal
+    category: terminal
+    platform: [windows]
     icon: windowsterminal
     color: text
-    os: [windows]
 xcode:
+    name: Xcode
+    category: code_editor
+    platform: [macos]
     color: blue
-    os: [macos]
 xfce4-terminal:
+    name: Xfce4 Terminal
+    category: terminal
+    platform: [linux]
     icon: xfce.svg
-    os: [linux]
 xresources:
+    name: Xresources
+    category: system
+    platform: [linux]
     icon: xdotorg
-    os: [linux]
 youtube:
+    name: YouTube
+    category: social
+    platform: userstyle
     color: red
 youtubemusic:
+    name: YouTube Musics
+    category: leisure
+    platform: userstyle
+    color: red
 zathura:
+    name: Zathura
+    category: productivity
+    platform: [linux]
     icon: zathura.svg
-    os: [linux]
 zellij:
+    name: Zellij
+    category: cli
+    platform: [linux, macos]
     icon: zellij.svg
-    os: [linux, macos]
 zsh-syntax-highlighting:
-    os: [linux, macos]
+    name: zsh-syntax-highlighting
+    category: cli
+    platform: [linux, macos]
 zutty:
-    os: [linux]
+    name: Zutty
+    category: terminal
+    platform: [linux]
+# yaml-language-server: $schema=https://raw.githubusercontent.com/catppuccin/catppuccin/main/resources/ports.schema.json


### PR DESCRIPTION
This will add autocompletion for the `resources/ports.yml` file, as well as keep track of more metadata for each port, such as:
- supported operating systems
- whether the port is a userstyle
- category assigned in the README

The end goal is for the ports.yml to auto-generate the Ports section in our README.