### PR TITLE
docs(showcase): add Simple MP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1126,6 +1126,7 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 - [Invidious](https://github.com/catppuccin/invidious)
 - [Libreddit](https://github.com/catppuccin/libreddit)
 - [Mastodon](https://github.com/catppuccin/mastodon)
+- [Misskey](https://github.com/catppuccin/misskey)
 - [Nitter](https://github.com/catppuccin/nitter)
 - [Reddit](https://github.com/catppuccin/reddit)
 - [Twitch](https://github.com/catppuccin/twitch)

--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -962,4 +962,7 @@ showcases:
     - title: faerber
       description: Website for applying custom color schemes to any wallpaper
       link: https://farbenfroh.io/faerber
+    - title: Simple MP
+      description: A simple music player based on Material You design
+      link: https://github.com/lighttigerXIV/SimpleMP-Compose
 # yaml-language-server: $schema=https://raw.githubusercontent.com/catppuccin/catppuccin/main/resources/ports.schema.json


### PR DESCRIPTION
Actually adds it to the Showcase section, followup for #1932.
I forgot that this part of the README is auto-generated as well.