### PR TITLE
fix(build): use npm import for ajv

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,6 +965,7 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 - [NeoMutt](https://github.com/catppuccin/neomutt)
 - [Newsboat](https://github.com/catppuccin/newsboat)
 - [sc-im](https://github.com/catppuccin/sc-im)
+- [Starship](https://github.com/catppuccin/starship)
 - [tmux](https://github.com/catppuccin/tmux)
 - [Zellij](https://github.com/catppuccin/zellij)
 - [zsh-syntax-highlighting](https://github.com/catppuccin/zsh-syntax-highlighting)

--- a/resources/generate/deno.lock
+++ b/resources/generate/deno.lock
@@ -57,56 +57,44 @@
     "https://deno.land/std@0.172.0/path/posix.ts": "0874b341c2c6968ca38d323338b8b295ea1dae10fa872a768d812e2e7d634789",
     "https://deno.land/std@0.172.0/path/separator.ts": "0fb679739d0d1d7bf45b68dacfb4ec7563597a902edbaf3c59b50d5bcadd93b1",
     "https://deno.land/std@0.172.0/path/win32.ts": "672942919dd66ce1b8c224e77d3447e2ad8254eaff13fe6946420a9f78fa141e",
-    "https://deno.land/std@0.172.0/types.d.ts": "220ed56662a0bd393ba5d124aa6ae2ad36a00d2fcbc0e8666a65f4606aaa9784",
-    "https://esm.sh/ajv@8.12.0": "594b01900aff1e27d4c419046dd09ac30290281839e784253f53b66f47898108",
-    "https://esm.sh/v106/ajv@8.12.0/deno/ajv.js": "23854337afccdad144d7f2f1f165dc7361882a8cd5644e7e56ec311697f80cc6",
-    "https://esm.sh/v106/ajv@8.12.0/dist/ajv.d.ts": "e2efa41fff63778572ae1d04dc9d62048684aa8aad6edd0218e562402ea9e0ec",
-    "https://esm.sh/v106/ajv@8.12.0/dist/compile/codegen/code.d.ts": "2d225e7bda2871c066a7079c88174340950fb604f624f2586d3ea27bb9e5f4ff",
-    "https://esm.sh/v106/ajv@8.12.0/dist/compile/codegen/index.d.ts": "9785e1199bae7389a92831c1f732fa72fc6f34a9c3f8948a5acfc8451e72f833",
-    "https://esm.sh/v106/ajv@8.12.0/dist/compile/codegen/scope.d.ts": "4ad65126bd23e1b8fe40f5375b812676694dccc232060a53bff52ac416aef059",
-    "https://esm.sh/v106/ajv@8.12.0/dist/compile/errors.d.ts": "65c56e41c3ad2867c1c179e7cb8fd4fcbb4cdaa172e2cc5242fbbfab4be089c0",
-    "https://esm.sh/v106/ajv@8.12.0/dist/compile/index.d.ts": "dc63e8445111329e56e443e63cc892632015ddbfa76170e4959b4d876535285e",
-    "https://esm.sh/v106/ajv@8.12.0/dist/compile/ref_error.d.ts": "b5e33c3fb8302173827cb3ee68d45c9ff45d2e8ec2a9b347ede1f0b5e00ccdf3",
-    "https://esm.sh/v106/ajv@8.12.0/dist/compile/resolve.d.ts": "23d18dca3d3b9b1c85cffc826914219e39db265aa3bd2eb1259cdce013a4a94a",
-    "https://esm.sh/v106/ajv@8.12.0/dist/compile/rules.d.ts": "18e085a67ae0ea81f7d4539e8f682f0b9b150b12af9e66f7760a03356aec507f",
-    "https://esm.sh/v106/ajv@8.12.0/dist/compile/util.d.ts": "3acaa483c7cf47fc5ced1473b830ec37a8f0d40238f3d96246657c970e13e6c7",
-    "https://esm.sh/v106/ajv@8.12.0/dist/compile/validate/dataType.d.ts": "4f56c2ba7307d8d5749dd4b60fadab04dce7d69838e129d04c3837cb397ce5bf",
-    "https://esm.sh/v106/ajv@8.12.0/dist/compile/validate/index.d.ts": "3e1bff49fa21ad6c11d06b5074fd623443dbd5db8fed3bd78411232401a0313e",
-    "https://esm.sh/v106/ajv@8.12.0/dist/compile/validate/subschema.d.ts": "79ae0a30e9f503b57d8c698e40f1141de1ff05d36dc9b08bc9b3ed6fe1074f9f",
-    "https://esm.sh/v106/ajv@8.12.0/dist/core.d.ts": "c0d24ae17225116e4895c1961a957acb2158c3ea3f2164ede7b726fc1112edf7",
-    "https://esm.sh/v106/ajv@8.12.0/dist/runtime/validation_error.d.ts": "515ba5900e0017f5512f442a31826d4210ac782b9b6fad6dbfcab61b5f8c881f",
-    "https://esm.sh/v106/ajv@8.12.0/dist/types/index.d.ts": "7fdb4bb0d8c9559e391d89e36061ffb02e30b8b7886c246cffeb793937a5f404",
-    "https://esm.sh/v106/ajv@8.12.0/dist/types/json-schema.d.ts": "6b6ed4aa017eb6867cef27257379cfe3e16caf628aceae3f0163dbafcaf891ff",
-    "https://esm.sh/v106/ajv@8.12.0/dist/types/jtd-schema.d.ts": "25f1159094dc0bf3a71313a74e0885426af21c5d6564a254004f2cadf9c5b052",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/applicator/additionalItems.d.ts": "810dc8272ea4023b647017ee4ff3ababce2a186c48a1e371e0fb631ed5bf9499",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/applicator/additionalProperties.d.ts": "93eafd639403aca489d2a2bd26fb89b46a855a271fa3685df23d3f3cfd6c7781",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/applicator/anyOf.d.ts": "3bcf9e93173ce018235392adf8ac6b9d4173b632d2fbd74e083f58c5e8dda50d",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/applicator/contains.d.ts": "e271ef23f0eecaa3bc3241429c25694aab4e47d96b8bd564d68e077ca2155251",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/applicator/dependencies.d.ts": "4da778139fb84dce56f1bb4ef757c17d891a9e3f0f5cff5b835ebde09ac1e956",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/applicator/if.d.ts": "48955ffe23bd06877c1bbc7f364a9e80f2dae56783fbfb79c16520375c376230",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/applicator/index.d.ts": "16bea08752cd2ca1eabbeb11ebddd265f4150cf171c1041e11a0501f35a49d4e",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/applicator/items2020.d.ts": "263fb5e5115873391f99a45bab2e975b0483e8a45da95bdecdbec6760c127aa4",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/applicator/not.d.ts": "869d7db4971ca299ff238ca0ea8b3d5cd752b449ccb6559790db0c8ad0c5dfbe",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/applicator/oneOf.d.ts": "385baa5077f5878b7506ec9192fd7ab686f7fda6276b71b877ecc0424c24badb",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/applicator/propertyNames.d.ts": "2b379d5bc77776abe065fab1e47f84929f6274e0e380c0c1c27a6965e7f4aabc",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/discriminator/index.d.ts": "d6f1fa129cf004b83f2913b3b3094d510e77b421f87ed6ee69f5f89b493fe91b",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/discriminator/types.d.ts": "cdcdcd676aa93fb9822b91569f06178c6cdcbb216f6dab289cc193ac99638838",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/errors.d.ts": "673f52fa2cc7f047ab6f369d12ed82088358174fd58474329d79fa999e3ce635",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/format/format.d.ts": "1fbffe88e41ab623cdd71ef300206298a6780ed9fd1abfd7d63f1892379c7e9a",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/unevaluated/unevaluatedItems.d.ts": "8b9b8c5189417cda763245be14d202e1a199091f1b0b3a0f4c957bdb85ffd044",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/unevaluated/unevaluatedProperties.d.ts": "4e10c976131382776b03ab8cee68e7764c9bf7db1ab9132066bb0d1f640c03fe",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/validation/const.d.ts": "90985bc6fed39fd595acab2f8f91ce2274b46c9ec7f68d9624d4a677fb206ae8",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/validation/dependentRequired.d.ts": "632b0af8992f86056e5571fbb148835d582332bb613c4e80fdf6719c501483c5",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/validation/enum.d.ts": "15663b84b4d935e1a282269a9ac1072c96d9351c941fa959469cd1ba2419b148",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/validation/index.d.ts": "d05ad2c8e4613c06e314105aaa7b43caa7a373e5f2671c51053bc9160803fbd5",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/validation/limitNumber.d.ts": "3b4220c15eacf28d3732f9df3a2ad0908b9a388dc9d13c35311233f11c28dd36",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/validation/multipleOf.d.ts": "a62b50d44d9c8d0e26b3b42eb90fe87ad1fad683122aa076e6f8d30fb056ad5f",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/validation/pattern.d.ts": "bc7f68367bbd6bdf9ed47aae8590770c7ec7ad6d44c0de11df696162038224b1",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/validation/required.d.ts": "7a14df7f7a58dd22ca4ca449f39cc0168eec566c95d9d7950e5b91da50bf4415",
-    "https://esm.sh/v106/ajv@8.12.0/dist/vocabularies/validation/uniqueItems.d.ts": "9a9056c3705215ba3289f7ad913e92babeca6e53091aa8095ee85e66ee2bd089",
-    "https://esm.sh/v106/fast-deep-equal@3.1.3/deno/fast-deep-equal.js": "4695b025e9a792678087d71f58e1fa07e8021b636d22fda8c0320fcff65a3c47",
-    "https://esm.sh/v106/json-schema-traverse@1.0.0/deno/json-schema-traverse.js": "ff987aaea4950aa9c4eea3ca19c9ec2b3229434e22e711415aa77fb513689a9c",
-    "https://esm.sh/v106/uri-js@4.4.1/deno/uri-js.js": "cb0fe68d76c29d62c7b79baf964e1b1c6623039faae892514776f0680711fc3e",
-    "https://esm.sh/v106/uri-js@4.4.1/dist/es5/uri.all.d.ts": "9f3c5498245c38c9016a369795ec5ef1768d09db63643c8dba9656e5ab294825"
+    "https://deno.land/std@0.172.0/types.d.ts": "220ed56662a0bd393ba5d124aa6ae2ad36a00d2fcbc0e8666a65f4606aaa9784"
+  },
+  "npm": {
+    "specifiers": {
+      "ajv@8.12.0": "ajv@8.12.0"
+    },
+    "packages": {
+      "ajv@8.12.0": {
+        "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+        "dependencies": {
+          "fast-deep-equal": "fast-deep-equal@3.1.3",
+          "json-schema-traverse": "json-schema-traverse@1.0.0",
+          "require-from-string": "require-from-string@2.0.2",
+          "uri-js": "uri-js@4.4.1"
+        }
+      },
+      "fast-deep-equal@3.1.3": {
+        "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+        "dependencies": {}
+      },
+      "json-schema-traverse@1.0.0": {
+        "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+        "dependencies": {}
+      },
+      "punycode@2.3.0": {
+        "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+        "dependencies": {}
+      },
+      "require-from-string@2.0.2": {
+        "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+        "dependencies": {}
+      },
+      "uri-js@4.4.1": {
+        "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+        "dependencies": {
+          "punycode": "punycode@2.3.0"
+        }
+      }
+    }
   }
 }

--- a/resources/generate/deps.ts
+++ b/resources/generate/deps.ts
@@ -1,6 +1,6 @@
 export { parse as parseYaml } from "https://deno.land/std@0.172.0/encoding/yaml.ts";
 
-import Ajv from "https://esm.sh/ajv@8.12.0";
+import Ajv from "npm:ajv@8.12.0";
 import * as path from "https://deno.land/std@0.172.0/path/mod.ts";
 import schema from "../ports.schema.json" assert { type: "json" };
 


### PR DESCRIPTION
Fixing a remnant of Deno 1.29 being broken with this library.