### PR TITLE
docs: add step to delete existing `.git` history

### DIFF
--- a/docs/port-creation.md
+++ b/docs/port-creation.md
@@ -128,8 +128,8 @@ template as a blueprint.
    ```
 
 4. Squash previous commits down to one initial commit
-> This removes the template authors from appearing as contributors to your new port
 
+   > This removes the template authors from appearing as contributors to your new port
    ```
    git reset $(git commit-tree HEAD^{tree} -m "init: Start new port")
    ```

--- a/docs/port-creation.md
+++ b/docs/port-creation.md
@@ -127,7 +127,14 @@ template as a blueprint.
    git remote remove origin
    ```
 
-4. Set up the rest of your port, and push it to your user repository!
+4. Squash previous commits down to one initial commit
+> This removes the template authors from appearing as contributors to your new port
+
+   ```
+   git reset $(git commit-tree HEAD^{tree} -m "init: Start new port")
+   ```
+
+5. Set up the rest of your port, and push it to your user repository!
 
 &nbsp;
 

--- a/docs/port-creation.md
+++ b/docs/port-creation.md
@@ -127,12 +127,7 @@ template as a blueprint.
    git remote remove origin
    ```
 
-4. Squash previous commits down to one initial commit
-
-   > This removes the template authors from appearing as contributors to your new port
-   ```
-   git reset $(git commit-tree HEAD^{tree} -m "init: Start new port")
-   ```
+4. Delete the `.git` folder at the root of the repository and run `git init`. This removes the template authors from appearing as contributors to your new port.
 
 5. Set up the rest of your port, and push it to your user repository!
 


### PR DESCRIPTION
While making my first port, I was advised by @nekowinston to use the following git line to "squash" previous commits to a new initial commit

`git reset $(git commit-tree HEAD^{tree} -m "init: Start new port")` poking around stack overflow, this seems like the conventional way to go about this

This might be common knowledge and I just don't know a better way, but it may be worth adding as a step in the template cloning process