### PR TITLE
docs: youtube-music is not a userstyle

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -912,7 +912,7 @@ ports:
     youtubemusic:
         name: YouTube Music
         category: leisure
-        platform: userstyle
+        platform: agnostic
         color: red
     zathura:
         name: Zathura


### PR DESCRIPTION
As discussed on discord, the youtube-music userstyle has
separate css files and supports desktop clients alongside
stylus. As this is now similar to the discord port
which we are currently not including, we should not label
this as a userstyle.

We may come back and revisit this decision at a later point
in time.