### PR TITLE
docs(readme): unify palette & usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Join our community!
 
 ### 🎨 Palette
 
-**Catppuccin** consists of 4 beautiful pastel color palettes, named **flavours**. All the details can be found below.<br>
+**Catppuccin** consists of 4 beautiful pastel color palettes, named **flavors**. All the details can be found below.<br>
 If you want to use them for your own project please refer to our [style guide](https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md) for general use cases and guidelines, and [catppuccin/palette](https://github.com/catppuccin/palette) where you can find integrations with popular frameworks and tools.
 
 Already have a project making use of our palette? Don't forget to add it to

--- a/README.md
+++ b/README.md
@@ -103,9 +103,11 @@ Join our community!
 
 ### 🎨 Palette
 
-**Catppuccin** consists of 4 beautiful pastel color palettes, named **flavors**. All the details can be found below.<br>
-To make the best use of them, please refer to
-the [style guide](https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md).
+**Catppuccin** consists of 4 beautiful pastel color palettes, named **flavours**. All the details can be found below.<br>
+If you want to use them for your own project please refer to our [style guide](https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md) for general use cases and guidelines, and [catppuccin/palette](https://github.com/catppuccin/palette) where you can find integrations with popular frameworks and tools.
+
+Already have a project making use of our palette? Don't forget to add it to
+our [showcase](#-showcase) section below!
 <br><img src="assets/misc/transparent.png" height="10" width="0" />
 
 <details>
@@ -887,17 +889,6 @@ the [style guide](https://github.com/catppuccin/catppuccin/blob/main/docs/style-
 	</tr>
 </table>
 </details>
-
-&nbsp;
-
-### 🔧 Usage
-
-If you're interested in using our palette for your own project, make sure to check
-out [catppuccin/palette](https://github.com/catppuccin/palette) where you can find integrations with popular frameworks
-and tools.
-
-Already have a project making use of our palette? Don't forget to add it to
-our [showcase](#-showcase) section below!
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Join our community!
 ### 🎨 Palette
 
 **Catppuccin** consists of 4 beautiful pastel color palettes, named **flavors**. All the details can be found below.<br>
-If you want to use them for your own project please refer to our [style guide](https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md) for general use cases and guidelines, and [catppuccin/palette](https://github.com/catppuccin/palette) where you can find integrations with popular frameworks and tools.
+If you want to use them for your own project, refer to our [style guide](https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md) for general use cases and guidelines. Additionally, you can find integrations with popular frameworks and tools in [catppuccin/palette](https://github.com/catppuccin/palette).
 
 Already have a project making use of our palette? Don't forget to add it to
 our [showcase](#-showcase) section below!


### PR DESCRIPTION
> Personally, the section of the docs called palette serves too similar of a purpose to usage and I know they are technically different but without a doubt they could be combined. I am starting this discussion to see what other people think of this.
~ @isabelroses 

As discussed over on Discord – here is a porposal for the unification. c: