### PR TITLE
build: retrieve userstyles from `catppuccin/userstyles`

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,7 +950,7 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 - [mdBook](https://github.com/catppuccin/mdBook)
 - [Tailwind CSS](https://github.com/catppuccin/tailwindcss)
 - [Unreal Engine](https://github.com/catppuccin/unreal-engine)
-- [Vercel](https://github.com/catppuccin/vercel)
+- [Vercel](https://github.com/catppuccin/userstyles/tree/main/styles/vercel)
 
 </details>
 <details open>
@@ -1087,10 +1087,10 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 <details open>
 <summary>🔎 Search Engines</summary>
 
-- [Brave Search](https://github.com/catppuccin/brave-search)
+- [Brave Search](https://github.com/catppuccin/userstyles/tree/main/styles/brave-search)
 - [DuckDuckGo](https://github.com/catppuccin/duckduckgo)
-- [NixOS Search](https://github.com/catppuccin/nixos-search)
-- [SearXNG](https://github.com/catppuccin/SearXNG)
+- [NixOS Search](https://github.com/catppuccin/userstyles/tree/main/styles/nixos-search)
+- [SearXNG](https://github.com/catppuccin/userstyles/tree/main/styles/searxng)
 - [Startpage](https://github.com/catppuccin/startpage)
 - [Whoogle](https://github.com/catppuccin/whoogle)
 
@@ -1099,7 +1099,7 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 <summary>💬 Messaging</summary>
 
 - [Aliucord](https://github.com/catppuccin/aliucord)
-- [Cinny](https://github.com/catppuccin/cinny)
+- [Cinny](https://github.com/catppuccin/userstyles/tree/main/styles/cinny)
 - [Discord](https://github.com/catppuccin/discord)
 - [Element](https://github.com/catppuccin/element)
 - [Enmity](https://github.com/catppuccin/enmity)
@@ -1127,59 +1127,59 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 - [Alfred](https://github.com/catppuccin/alfred)
 - [Anki](https://github.com/catppuccin/anki)
 - [Bento](https://github.com/catppuccin/bento)
-- [Codeberg](https://github.com/catppuccin/codeberg)
-- [DeepL](https://github.com/catppuccin/deepl)
+- [Codeberg](https://github.com/catppuccin/userstyles/tree/main/styles/codeberg)
+- [DeepL](https://github.com/catppuccin/userstyles/tree/main/styles/deepl)
 - [DioHub](https://github.com/catppuccin/diohub)
 - [Foliate](https://github.com/catppuccin/foliate)
 - [FreshRSS](https://github.com/catppuccin/freshrss)
 - [ghostwriter](https://github.com/catppuccin/ghostwriter)
 - [Gitea](https://github.com/catppuccin/gitea)
-- [GitHub](https://github.com/catppuccin/github)
-- [ichi.moe](https://github.com/catppuccin/ichi.moe)
+- [GitHub](https://github.com/catppuccin/userstyles/tree/main/styles/github)
+- [ichi.moe](https://github.com/catppuccin/userstyles/tree/main/styles/ichi.moe)
 - [Mailspring](https://github.com/catppuccin/mailspring)
 - [OBS Studio](https://github.com/catppuccin/obs)
 - [Pomotroid](https://github.com/catppuccin/pomotroid)
 - [PowerPoint Slides](https://github.com/catppuccin/powerpoint-slides)
-- [Proton](https://github.com/catppuccin/proton)
+- [Proton](https://github.com/catppuccin/userstyles/tree/main/styles/proton)
 - [qBittorrent](https://github.com/catppuccin/qbittorrent)
 - [Raycast](https://github.com/catppuccin/raycast)
 - [ShareX](https://github.com/catppuccin/sharex)
 - [SolveSpace](https://github.com/catppuccin/solvespace)
 - [SumatraPDF](https://github.com/catppuccin/sumatra-pdf)
 - [Thunderbird](https://github.com/catppuccin/thunderbird)
-- [Tutanota](https://github.com/catppuccin/tutanota)
-- [WikiWand](https://github.com/catppuccin/wikiwand)
+- [Tutanota](https://github.com/catppuccin/userstyles/tree/main/styles/tutanota)
+- [WikiWand](https://github.com/catppuccin/userstyles/tree/main/styles/wikiwand)
 - [Zathura](https://github.com/catppuccin/zathura)
 
 </details>
 <details open>
 <summary>✨ Social</summary>
 
-- [Elk](https://github.com/catppuccin/elk)
+- [Elk](https://github.com/catppuccin/userstyles/tree/main/styles/elk)
 - [GitHub Readme Stats](https://github.com/catppuccin/github-readme-stats)
 - [GitHub Readme Tech Stack](https://github.com/catppuccin/github-readme-tech-stack)
-- [Hacker News](https://github.com/catppuccin/hacker-news)
+- [Hacker News](https://github.com/catppuccin/userstyles/tree/main/styles/hacker-news)
 - [Infinity for Reddit](https://github.com/catppuccin/infinity)
-- [Invidious](https://github.com/catppuccin/invidious)
-- [Libreddit](https://github.com/catppuccin/libreddit)
-- [Mastodon](https://github.com/catppuccin/mastodon)
+- [Invidious](https://github.com/catppuccin/userstyles/tree/main/styles/invidious)
+- [Libreddit](https://github.com/catppuccin/userstyles/tree/main/styles/libreddit)
+- [Mastodon](https://github.com/catppuccin/userstyles/tree/main/styles/mastodon)
 - [Misskey](https://github.com/catppuccin/misskey)
-- [Nitter](https://github.com/catppuccin/nitter)
-- [Reddit](https://github.com/catppuccin/reddit)
-- [Twitch](https://github.com/catppuccin/twitch)
-- [YouTube](https://github.com/catppuccin/youtube)
+- [Nitter](https://github.com/catppuccin/userstyles/tree/main/styles/nitter)
+- [Reddit](https://github.com/catppuccin/userstyles/tree/main/styles/reddit)
+- [Twitch](https://github.com/catppuccin/userstyles/tree/main/styles/twitch)
+- [YouTube](https://github.com/catppuccin/userstyles/tree/main/styles/youtube)
 
 </details>
 <details open>
 <summary>🌈 Leisure</summary>
 
 - [Amfora](https://github.com/catppuccin/amfora)
-- [AniList](https://github.com/catppuccin/anilist)
+- [AniList, AniChart](https://github.com/catppuccin/userstyles/tree/main/styles/anilist)
 - [Cider](https://github.com/catppuccin/cider)
 - [Dopamine](https://github.com/catppuccin/dopamine)
 - [Heroic](https://github.com/catppuccin/heroic)
 - [Home Assistant](https://github.com/catppuccin/home-assistant)
-- [Last.fm](https://github.com/catppuccin/lastfm)
+- [Last.fm](https://github.com/catppuccin/userstyles/tree/main/styles/lastfm)
 - [monkeytype](https://github.com/catppuccin/monkeytype)
 - [MusicBee](https://github.com/catppuccin/musicbee)
 - [PyRadio](https://github.com/catppuccin/pyradio)
@@ -1199,7 +1199,7 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 - [Blockbench](https://github.com/catppuccin/blockbench)
 - [Dwarf Fortress](https://github.com/catppuccin/dwarf-fortress)
 - [Minecraft](https://github.com/catppuccin/minecraft)
-- [Modrinth](https://github.com/catppuccin/modrinth)
+- [Modrinth](https://github.com/catppuccin/userstyles/tree/main/styles/modrinth)
 - [Moon Animator 2](https://github.com/catppuccin/moon-animator-2)
 - [Prism Launcher](https://github.com/catppuccin/prismlauncher)
 - [ULTRAKILL](https://github.com/catppuccin/ultrakill)

--- a/README.md
+++ b/README.md
@@ -950,7 +950,7 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 - [mdBook](https://github.com/catppuccin/mdBook)
 - [Tailwind CSS](https://github.com/catppuccin/tailwindcss)
 - [Unreal Engine](https://github.com/catppuccin/unreal-engine)
-- [Vercel](https://github.com/catppuccin/userstyles/tree/main/styles/vercel)
+- [Vercel](https://github.com/catppuccin/vercel)
 
 </details>
 <details open>
@@ -1088,10 +1088,10 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 <details open>
 <summary>🔎 Search Engines</summary>
 
-- [Brave Search](https://github.com/catppuccin/userstyles/tree/main/styles/brave-search)
+- [Brave Search](https://github.com/catppuccin/brave-search)
 - [DuckDuckGo](https://github.com/catppuccin/duckduckgo)
-- [NixOS Search](https://github.com/catppuccin/userstyles/tree/main/styles/nixos-search)
-- [SearXNG](https://github.com/catppuccin/userstyles/tree/main/styles/searxng)
+- [NixOS Search](https://github.com/catppuccin/nixos-search)
+- [SearXNG](https://github.com/catppuccin/SearXNG)
 - [Startpage](https://github.com/catppuccin/startpage)
 - [Whoogle](https://github.com/catppuccin/whoogle)
 
@@ -1100,7 +1100,7 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 <summary>💬 Messaging</summary>
 
 - [Aliucord](https://github.com/catppuccin/aliucord)
-- [Cinny](https://github.com/catppuccin/userstyles/tree/main/styles/cinny)
+- [Cinny](https://github.com/catppuccin/cinny)
 - [Discord](https://github.com/catppuccin/discord)
 - [Element](https://github.com/catppuccin/element)
 - [Enmity](https://github.com/catppuccin/enmity)
@@ -1128,59 +1128,59 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 - [Alfred](https://github.com/catppuccin/alfred)
 - [Anki](https://github.com/catppuccin/anki)
 - [Bento](https://github.com/catppuccin/bento)
-- [Codeberg](https://github.com/catppuccin/userstyles/tree/main/styles/codeberg)
-- [DeepL](https://github.com/catppuccin/userstyles/tree/main/styles/deepl)
+- [Codeberg](https://github.com/catppuccin/codeberg)
+- [DeepL](https://github.com/catppuccin/deepl)
 - [DioHub](https://github.com/catppuccin/diohub)
 - [Foliate](https://github.com/catppuccin/foliate)
 - [FreshRSS](https://github.com/catppuccin/freshrss)
 - [ghostwriter](https://github.com/catppuccin/ghostwriter)
 - [Gitea](https://github.com/catppuccin/gitea)
-- [GitHub](https://github.com/catppuccin/userstyles/tree/main/styles/github)
-- [ichi.moe](https://github.com/catppuccin/userstyles/tree/main/styles/ichi.moe)
+- [GitHub](https://github.com/catppuccin/github)
+- [ichi.moe](https://github.com/catppuccin/ichi.moe)
 - [Mailspring](https://github.com/catppuccin/mailspring)
 - [OBS Studio](https://github.com/catppuccin/obs)
 - [Pomotroid](https://github.com/catppuccin/pomotroid)
 - [PowerPoint Slides](https://github.com/catppuccin/powerpoint-slides)
-- [Proton](https://github.com/catppuccin/userstyles/tree/main/styles/proton)
+- [Proton](https://github.com/catppuccin/proton)
 - [qBittorrent](https://github.com/catppuccin/qbittorrent)
 - [Raycast](https://github.com/catppuccin/raycast)
 - [ShareX](https://github.com/catppuccin/sharex)
 - [SolveSpace](https://github.com/catppuccin/solvespace)
 - [SumatraPDF](https://github.com/catppuccin/sumatra-pdf)
 - [Thunderbird](https://github.com/catppuccin/thunderbird)
-- [Tutanota](https://github.com/catppuccin/userstyles/tree/main/styles/tutanota)
-- [WikiWand](https://github.com/catppuccin/userstyles/tree/main/styles/wikiwand)
+- [Tutanota](https://github.com/catppuccin/tutanota)
+- [WikiWand](https://github.com/catppuccin/wikiwand)
 - [Zathura](https://github.com/catppuccin/zathura)
 
 </details>
 <details open>
 <summary>✨ Social</summary>
 
-- [Elk](https://github.com/catppuccin/userstyles/tree/main/styles/elk)
+- [Elk](https://github.com/catppuccin/elk)
 - [GitHub Readme Stats](https://github.com/catppuccin/github-readme-stats)
 - [GitHub Readme Tech Stack](https://github.com/catppuccin/github-readme-tech-stack)
-- [Hacker News](https://github.com/catppuccin/userstyles/tree/main/styles/hacker-news)
+- [Hacker News](https://github.com/catppuccin/hacker-news)
 - [Infinity for Reddit](https://github.com/catppuccin/infinity)
-- [Invidious](https://github.com/catppuccin/userstyles/tree/main/styles/invidious)
-- [Libreddit](https://github.com/catppuccin/userstyles/tree/main/styles/libreddit)
-- [Mastodon](https://github.com/catppuccin/userstyles/tree/main/styles/mastodon)
+- [Invidious](https://github.com/catppuccin/invidious)
+- [Libreddit](https://github.com/catppuccin/libreddit)
+- [Mastodon](https://github.com/catppuccin/mastodon)
 - [Misskey](https://github.com/catppuccin/misskey)
-- [Nitter](https://github.com/catppuccin/userstyles/tree/main/styles/nitter)
-- [Reddit](https://github.com/catppuccin/userstyles/tree/main/styles/reddit)
-- [Twitch](https://github.com/catppuccin/userstyles/tree/main/styles/twitch)
-- [YouTube](https://github.com/catppuccin/userstyles/tree/main/styles/youtube)
+- [Nitter](https://github.com/catppuccin/nitter)
+- [Reddit](https://github.com/catppuccin/reddit)
+- [Twitch](https://github.com/catppuccin/twitch)
+- [YouTube](https://github.com/catppuccin/youtube)
 
 </details>
 <details open>
 <summary>🌈 Leisure</summary>
 
 - [Amfora](https://github.com/catppuccin/amfora)
-- [AniList, AniChart](https://github.com/catppuccin/userstyles/tree/main/styles/anilist)
+- [AniList](https://github.com/catppuccin/anilist)
 - [Cider](https://github.com/catppuccin/cider)
 - [Dopamine](https://github.com/catppuccin/dopamine)
 - [Heroic](https://github.com/catppuccin/heroic)
 - [Home Assistant](https://github.com/catppuccin/home-assistant)
-- [Last.fm](https://github.com/catppuccin/userstyles/tree/main/styles/lastfm)
+- [Last.fm](https://github.com/catppuccin/lastfm)
 - [monkeytype](https://github.com/catppuccin/monkeytype)
 - [MusicBee](https://github.com/catppuccin/musicbee)
 - [PyRadio](https://github.com/catppuccin/pyradio)
@@ -1200,7 +1200,7 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 - [Blockbench](https://github.com/catppuccin/blockbench)
 - [Dwarf Fortress](https://github.com/catppuccin/dwarf-fortress)
 - [Minecraft](https://github.com/catppuccin/minecraft)
-- [Modrinth](https://github.com/catppuccin/userstyles/tree/main/styles/modrinth)
+- [Modrinth](https://github.com/catppuccin/modrinth)
 - [Moon Animator 2](https://github.com/catppuccin/moon-animator-2)
 - [Prism Launcher](https://github.com/catppuccin/prismlauncher)
 - [ULTRAKILL](https://github.com/catppuccin/ultrakill)

--- a/docs/port-creation.md
+++ b/docs/port-creation.md
@@ -13,6 +13,15 @@
 A port is an adaptation of Catppuccin's palette for an app to use. Think of it
 as a colorscheme for a program that styles every UI component it consists of!
 
+### What's a userstyle?
+
+A userstyle is, in the context of Catppuccin, a port for a website which is themed
+via [Stylus](https://github.com/openstyles/stylus), you can view all of Catppuccin's
+userstyles at [catppuccin/userstyles](https://github.com/catppuccin/userstyles).
+
+> **Note** <br> 
+> **All userstyles are ports, but not all ports are userstyles.**
+
 &nbsp;
 
 ### Submission
@@ -85,8 +94,13 @@ stateDiagram-v2
 since the port is already themed and ready to be reviewed by our
 [staff team](https://github.com/catppuccin/community/#current-structure)!
 
-**Q. I have a request for a port to be included and/or I've started working on
-it!**
+**Q. I have a userstyle that is already finished and ready for review!**
+
+**A.** Finished userstyles should be raised via a [pull request](https://github.com/catppuccin/userstyles/compare)
+to [catppuccin/userstyles](https://github.com/catppuccin/userstyles/compare). You can find further information on
+how to contribute userstyles [here](https://github.com/catppuccin/userstyles/blob/main/docs/userstyle-creation.md).
+
+**Q. I have a request for a port to be included and/or I've started working on it!**
 
 **A.** Raise a discussion under main repository
 [here](https://github.com/catppuccin/catppuccin/discussions/new?category=port-requests)!

--- a/docs/port-creation.md
+++ b/docs/port-creation.md
@@ -58,7 +58,7 @@ stateDiagram-v2
   idea --> choice
 
   choice: Have you already completed a draft?
-  choice --> draft_complete: Yes
+  choice --> is_userstyle: Yes
   choice --> request: No
 
   request: Open a Port Request discussion
@@ -69,6 +69,13 @@ stateDiagram-v2
 
   request_complete: The draft is completed to your liking
   request_complete --> draft_complete
+
+  is_userstyle: Is this themed via Stylus?
+  is_userstyle --> userstyle_review: Yes
+  is_userstyle --> draft_complete: No
+
+  userstyle_review: Submit pull request\nto catppuccin/userstyles
+  userstyle_review --> review
   
   draft_complete: Create a Port Review issue
   draft_complete --> review

--- a/resources/generate/deno.lock
+++ b/resources/generate/deno.lock
@@ -57,7 +57,8 @@
     "https://deno.land/std@0.172.0/path/posix.ts": "0874b341c2c6968ca38d323338b8b295ea1dae10fa872a768d812e2e7d634789",
     "https://deno.land/std@0.172.0/path/separator.ts": "0fb679739d0d1d7bf45b68dacfb4ec7563597a902edbaf3c59b50d5bcadd93b1",
     "https://deno.land/std@0.172.0/path/win32.ts": "672942919dd66ce1b8c224e77d3447e2ad8254eaff13fe6946420a9f78fa141e",
-    "https://deno.land/std@0.172.0/types.d.ts": "220ed56662a0bd393ba5d124aa6ae2ad36a00d2fcbc0e8666a65f4606aaa9784"
+    "https://deno.land/std@0.172.0/types.d.ts": "220ed56662a0bd393ba5d124aa6ae2ad36a00d2fcbc0e8666a65f4606aaa9784",
+    "https://raw.githubusercontent.com/catppuccin/userstyles/main/src/userstyles.schema.json": "6613d4fe2df651c606a885212b4232e5250e5f401f1b349d1801cf63428b0fab"
   },
   "npm": {
     "specifiers": {

--- a/resources/generate/deps.ts
+++ b/resources/generate/deps.ts
@@ -2,6 +2,11 @@ export { parse as parseYaml } from "https://deno.land/std@0.172.0/encoding/yaml.
 
 import Ajv from "npm:ajv@8.12.0";
 import * as path from "https://deno.land/std@0.172.0/path/mod.ts";
-import schema from "../ports.schema.json" assert { type: "json" };
+import portsSchema from "../ports.schema.json" assert { type: "json" };
+const userstylesYaml = await fetch(
+  "https://raw.githubusercontent.com/catppuccin/userstyles/main/src/userstyles.yml",
+);
+import userstylesSchema from "https://raw.githubusercontent.com/catppuccin/userstyles/main/src/userstyles.schema.json" assert { type: "json" };
+import type { Userstyle, Userstyles } from "https://raw.githubusercontent.com/catppuccin/userstyles/main/src/generate/types.d.ts";
 
-export { Ajv, path, schema };
+export { Ajv, path, portsSchema, userstylesSchema, userstylesYaml, Userstyle, Userstyles };

--- a/resources/generate/main.ts
+++ b/resources/generate/main.ts
@@ -1,110 +1,145 @@
-#!/usr/bin/env -S deno run --allow-env --allow-read --allow-write
+#!/usr/bin/env -S deno run --allow-env --allow-read --allow-write --allow-net
 
-import { Ajv, parseYaml, path, schema } from "./deps.ts";
-import type { Categories, Port, Ports, Showcases } from "./types.d.ts";
+import {
+    Ajv,
+    parseYaml,
+    path,
+    portsSchema,
+    userstylesSchema,
+    userstylesYaml,
+    Userstyle,
+    Userstyles,
+} from './deps.ts'
+import type { Categories, Port, Ports, Showcases } from './types.d.ts'
 
-const root = new URL(".", import.meta.url).pathname;
+const root = new URL('.', import.meta.url).pathname
 
-type Metadata = {
-  categories: Categories;
-  ports: Ports;
-  showcases: Showcases;
-};
-
-const ajv = new Ajv();
-const validate = ajv.compile<Metadata>(schema);
-
-const portsYaml = Deno.readTextFileSync(path.join(root, "../ports.yml"));
-const data = parseYaml(portsYaml) as Metadata;
-
-// throw error if the YAML is invalid
-if (!validate(data)) {
-  console.log(validate.errors);
-  Deno.exit(1);
+type PortsMetadata = {
+    categories: Categories
+    ports: Ports
+    showcases: Showcases
 }
 
-export type MappedPort = Port & { html_url: string };
+type UserstylesMetadata = {
+    userstyles: Userstyles
+}
 
-const categorized = Object.entries(data.ports).reduce((acc, [slug, port]) => {
-  !acc[port.category] && (acc[port.category] = []);
-  acc[port.category].push({
-    html_url: `https://github.com/catppuccin/${slug}`,
-    ...port,
-  });
-  acc[port.category].sort((a, b) => a.name.localeCompare(b.name));
-  return acc;
-}, {} as Record<string, MappedPort[]>);
+const ajv = new Ajv()
+const validatePorts = ajv.compile<PortsMetadata>(portsSchema)
+const validateUserstyles = ajv.compile<PortsMetadata>(userstylesSchema)
 
-const portListData = data.categories.map((category) => {
-  return {
-    meta: category,
-    ports: categorized[category.key],
-  };
-});
+const portsYaml = Deno.readTextFileSync(path.join(root, '../ports.yml'))
+const portsData = parseYaml(portsYaml) as PortsMetadata
+
+const userstylesData = parseYaml(
+    await userstylesYaml.text()
+) as UserstylesMetadata
+
+// throw error if the YAML is invalid
+if (!validatePorts(portsData)) {
+    console.log(validatePorts.errors)
+    Deno.exit(1)
+}
+
+if (!validateUserstyles(userstylesData)) {
+    console.log(validateUserstyles.errors)
+    Deno.exit(1)
+}
+
+const ports = Object.assign(portsData.ports, userstylesData.userstyles)
+
+export type MappedPort = (Port | Userstyle) & { html_url: string }
+
+const categorized = Object.entries(ports).reduce(
+    (acc, [slug, port]: [string, MappedPort]) => {
+        !acc[port.category] && (acc[port.category] = [])
+        acc[port.category].push({
+            html_url: `https://github.com/catppuccin/${
+                port.readme ? `userstyles/tree/main/styles/${slug}` : slug
+            }`,
+            ...port,
+            name: [port.name].flat().join(', '),
+        })
+        acc[port.category].sort((a, b) => a.name.localeCompare(b.name))
+        return acc
+    },
+    {} as Record<string, MappedPort[]>
+)
+
+const portListData = portsData.categories.map((category) => {
+    return {
+        meta: category,
+        ports: categorized[category.key],
+    }
+})
 
 const updateReadme = ({
-  readme,
-  section,
-  newContent,
+    readme,
+    section,
+    newContent,
 }: {
-  readme: string;
-  section: string;
-  newContent: string;
+    readme: string
+    section: string
+    newContent: string
 }): string => {
-  const preamble =
-    "<!-- the following section is auto-generated, do not edit -->";
-  const markers = {
-    start: `<!-- AUTOGEN:${section.toUpperCase()} START -->`,
-    end: `<!-- AUTOGEN:${section.toUpperCase()} END -->`,
-  };
+    const preamble =
+        '<!-- the following section is auto-generated, do not edit -->'
+    const markers = {
+        start: `<!-- AUTOGEN:${section.toUpperCase()} START -->`,
+        end: `<!-- AUTOGEN:${section.toUpperCase()} END -->`,
+    }
 
-  const wrapped = markers.start + "\n" + preamble + "\n" + newContent + "\n" +
-    markers.end;
+    const wrapped =
+        markers.start + '\n' + preamble + '\n' + newContent + '\n' + markers.end
 
-  if (
-    !(
-      readmeContent.includes(markers.start) &&
-      readmeContent.includes(markers.end)
-    )
-  ) {
-    throw new Error("Markers not found in README.md");
-  }
+    if (
+        !(
+            readmeContent.includes(markers.start) &&
+            readmeContent.includes(markers.end)
+        )
+    ) {
+        throw new Error('Markers not found in README.md')
+    }
 
-  const pre = readme.split(markers.start)[0];
-  const end = readme.split(markers.end)[1];
+    const pre = readme.split(markers.start)[0]
+    const end = readme.split(markers.end)[1]
 
-  return pre + wrapped + end;
-};
+    return pre + wrapped + end
+}
 
-const readmePath = path.join(root, "../../README.md");
-let readmeContent = Deno.readTextFileSync(readmePath);
+const readmePath = path.join(root, '../../README.md')
+let readmeContent = Deno.readTextFileSync(readmePath)
 
-const portContent = portListData.map((data) => {
-  return `<details open>
+const portContent = portListData
+    .map((data) => {
+        return `<details open>
 <summary>${data.meta.emoji} ${data.meta.name}</summary>
 
-${data.ports.map((port) => `- [${port.name}](${port.html_url})`).join("\n")}
+${data.ports.map((port) => `- [${port.name}](${port.html_url})`).join('\n')}
 
-</details>`;
-}).join("\n");
+</details>`
+    })
+    .join('\n')
 
-const showcaseContent = data.showcases.map((showcase) => {
-  return `- [${showcase.title}](${showcase.link}) - ${showcase.description}`;
-}).join("\n");
+const showcaseContent = portsData.showcases
+    .map((showcase) => {
+        return `- [${showcase.title}](${showcase.link}) - ${showcase.description}`
+    })
+    .join('\n')
 
 try {
-  readmeContent = updateReadme({
-    readme: readmeContent,
-    section: "portlist",
-    newContent: portContent,
-  });
-  readmeContent = updateReadme({
-    readme: readmeContent,
-    section: "showcase",
-    newContent: showcaseContent,
-  });
+    readmeContent = updateReadme({
+        readme: readmeContent,
+        section: 'portlist',
+        newContent: portContent,
+    })
+    readmeContent = updateReadme({
+        readme: readmeContent,
+        section: 'showcase',
+        newContent: showcaseContent,
+    })
 } catch (e) {
-  console.log("Failed to update the README:", e);
+    console.log('Failed to update the README:', e)
 } finally {
-  Deno.writeTextFileSync(readmePath, readmeContent);
+    Deno.writeTextFileSync(readmePath, readmeContent)
 }

--- a/resources/generate/main.ts
+++ b/resources/generate/main.ts
@@ -1,145 +1,145 @@
 #!/usr/bin/env -S deno run --allow-env --allow-read --allow-write --allow-net
 
 import {
-    Ajv,
-    parseYaml,
-    path,
-    portsSchema,
-    userstylesSchema,
-    userstylesYaml,
-    Userstyle,
-    Userstyles,
-} from './deps.ts'
-import type { Categories, Port, Ports, Showcases } from './types.d.ts'
+  Ajv,
+  parseYaml,
+  path,
+  portsSchema,
+  Userstyle,
+  Userstyles,
+  userstylesSchema,
+  userstylesYaml,
+} from "./deps.ts";
+import type { Categories, Port, Ports, Showcases } from "./types.d.ts";
 
-const root = new URL('.', import.meta.url).pathname
+const root = new URL(".", import.meta.url).pathname;
 
 type PortsMetadata = {
-    categories: Categories
-    ports: Ports
-    showcases: Showcases
-}
+  categories: Categories;
+  ports: Ports;
+  showcases: Showcases;
+};
 
 type UserstylesMetadata = {
-    userstyles: Userstyles
-}
+  userstyles: Userstyles;
+};
 
-const ajv = new Ajv()
-const validatePorts = ajv.compile<PortsMetadata>(portsSchema)
-const validateUserstyles = ajv.compile<PortsMetadata>(userstylesSchema)
+const ajv = new Ajv();
+const validatePorts = ajv.compile<PortsMetadata>(portsSchema);
+const validateUserstyles = ajv.compile<PortsMetadata>(userstylesSchema);
 
-const portsYaml = Deno.readTextFileSync(path.join(root, '../ports.yml'))
-const portsData = parseYaml(portsYaml) as PortsMetadata
+const portsYaml = Deno.readTextFileSync(path.join(root, "../ports.yml"));
+const portsData = parseYaml(portsYaml) as PortsMetadata;
 
 const userstylesData = parseYaml(
-    await userstylesYaml.text()
-) as UserstylesMetadata
+  await userstylesYaml.text(),
+) as UserstylesMetadata;
 
 // throw error if the YAML is invalid
 if (!validatePorts(portsData)) {
-    console.log(validatePorts.errors)
-    Deno.exit(1)
+  console.log(validatePorts.errors);
+  Deno.exit(1);
 }
 
 if (!validateUserstyles(userstylesData)) {
-    console.log(validateUserstyles.errors)
-    Deno.exit(1)
+  console.log(validateUserstyles.errors);
+  Deno.exit(1);
 }
 
-const ports = Object.assign(portsData.ports, userstylesData.userstyles)
+const ports = Object.assign(portsData.ports, userstylesData.userstyles);
 
-export type MappedPort = (Port | Userstyle) & { html_url: string }
+export type MappedPort = (Port | Userstyle) & { html_url: string };
 
 const categorized = Object.entries(ports).reduce(
-    (acc, [slug, port]: [string, MappedPort]) => {
-        !acc[port.category] && (acc[port.category] = [])
-        acc[port.category].push({
-            html_url: `https://github.com/catppuccin/${
-                port.readme ? `userstyles/tree/main/styles/${slug}` : slug
-            }`,
-            ...port,
-            name: [port.name].flat().join(', '),
-        })
-        acc[port.category].sort((a, b) => a.name.localeCompare(b.name))
-        return acc
-    },
-    {} as Record<string, MappedPort[]>
-)
+  (acc, [slug, port]: [string, MappedPort]) => {
+    !acc[port.category] && (acc[port.category] = []);
+    acc[port.category].push({
+      html_url: `https://github.com/catppuccin/${
+        port.readme ? `userstyles/tree/main/styles/${slug}` : slug
+      }`,
+      ...port,
+      name: [port.name].flat().join(", "),
+    });
+    acc[port.category].sort((a, b) => a.name.localeCompare(b.name));
+    return acc;
+  },
+  {} as Record<string, MappedPort[]>,
+);
 
 const portListData = portsData.categories.map((category) => {
-    return {
-        meta: category,
-        ports: categorized[category.key],
-    }
-})
+  return {
+    meta: category,
+    ports: categorized[category.key],
+  };
+});
 
 const updateReadme = ({
-    readme,
-    section,
-    newContent,
+  readme,
+  section,
+  newContent,
 }: {
-    readme: string
-    section: string
-    newContent: string
+  readme: string;
+  section: string;
+  newContent: string;
 }): string => {
-    const preamble =
-        '<!-- the following section is auto-generated, do not edit -->'
-    const markers = {
-        start: `<!-- AUTOGEN:${section.toUpperCase()} START -->`,
-        end: `<!-- AUTOGEN:${section.toUpperCase()} END -->`,
-    }
+  const preamble =
+    "<!-- the following section is auto-generated, do not edit -->";
+  const markers = {
+    start: `<!-- AUTOGEN:${section.toUpperCase()} START -->`,
+    end: `<!-- AUTOGEN:${section.toUpperCase()} END -->`,
+  };
 
-    const wrapped =
-        markers.start + '\n' + preamble + '\n' + newContent + '\n' + markers.end
+  const wrapped = markers.start + "\n" + preamble + "\n" + newContent + "\n" +
+    markers.end;
 
-    if (
-        !(
-            readmeContent.includes(markers.start) &&
-            readmeContent.includes(markers.end)
-        )
-    ) {
-        throw new Error('Markers not found in README.md')
-    }
+  if (
+    !(
+      readmeContent.includes(markers.start) &&
+      readmeContent.includes(markers.end)
+    )
+  ) {
+    throw new Error("Markers not found in README.md");
+  }
 
-    const pre = readme.split(markers.start)[0]
-    const end = readme.split(markers.end)[1]
+  const pre = readme.split(markers.start)[0];
+  const end = readme.split(markers.end)[1];
 
-    return pre + wrapped + end
-}
+  return pre + wrapped + end;
+};
 
-const readmePath = path.join(root, '../../README.md')
-let readmeContent = Deno.readTextFileSync(readmePath)
+const readmePath = path.join(root, "../../README.md");
+let readmeContent = Deno.readTextFileSync(readmePath);
 
 const portContent = portListData
-    .map((data) => {
-        return `<details open>
+  .map((data) => {
+    return `<details open>
 <summary>${data.meta.emoji} ${data.meta.name}</summary>
 
-${data.ports.map((port) => `- [${port.name}](${port.html_url})`).join('\n')}
+${data.ports.map((port) => `- [${port.name}](${port.html_url})`).join("\n")}
 
-</details>`
-    })
-    .join('\n')
+</details>`;
+  })
+  .join("\n");
 
 const showcaseContent = portsData.showcases
-    .map((showcase) => {
-        return `- [${showcase.title}](${showcase.link}) - ${showcase.description}`
-    })
-    .join('\n')
+  .map((showcase) => {
+    return `- [${showcase.title}](${showcase.link}) - ${showcase.description}`;
+  })
+  .join("\n");
 
 try {
-    readmeContent = updateReadme({
-        readme: readmeContent,
-        section: 'portlist',
-        newContent: portContent,
-    })
-    readmeContent = updateReadme({
-        readme: readmeContent,
-        section: 'showcase',
-        newContent: showcaseContent,
-    })
+  readmeContent = updateReadme({
+    readme: readmeContent,
+    section: "portlist",
+    newContent: portContent,
+  });
+  readmeContent = updateReadme({
+    readme: readmeContent,
+    section: "showcase",
+    newContent: showcaseContent,
+  });
 } catch (e) {
-    console.log('Failed to update the README:', e)
+  console.log("Failed to update the README:", e);
 } finally {
-    Deno.writeTextFileSync(readmePath, readmeContent)
+  Deno.writeTextFileSync(readmePath, readmeContent);
 }

--- a/resources/generate/types.d.ts
+++ b/resources/generate/types.d.ts
@@ -51,15 +51,10 @@ export type Category =
   | "system"
   | "terminal";
 /**
- * The platforms the port supports. Either an array of supported operating systems, "agnostic" (indicating support for all platforms), or "userstyle".
+ * The platforms the port supports. Either an array of supported operating systems or "agnostic" (indicating support for all platforms).
  */
-export type Platform = OperatingSystems[] | ("agnostic" | "userstyle");
-export type OperatingSystems =
-  | "android"
-  | "ios"
-  | "linux"
-  | "macos"
-  | "windows";
+export type Platform = OperatingSystems[] | "agnostic";
+export type OperatingSystems = "android" | "ios" | "linux" | "macos" | "windows";
 /**
  * The fill color for the icon on the website.
  */
@@ -83,10 +78,6 @@ export type Color =
  * The icon to use on the website. This should be the same name as the SVG file on https://simpleicons.org/. If a `.svg` suffix is present, it's taken from the local website repository resources.
  */
 export type Icon = string;
-/**
- * Whether the port is a userstyle
- */
-export type Userstyle = boolean;
 export type Title = string;
 export type Link = string;
 export type Link1 = string;
@@ -123,7 +114,6 @@ export interface Port {
   platform: Platform;
   color?: Color;
   icon?: Icon;
-  userstyle?: Userstyle;
 }
 export interface ShowcaseItem {
   title: Title;

--- a/resources/ports.schema.json
+++ b/resources/ports.schema.json
@@ -77,7 +77,7 @@
             "platform": {
               "$id": "#ports/port/platform",
               "title": "Platform",
-              "description": "The platforms the port supports. Either an array of supported operating systems, \"agnostic\" (indicating support for all platforms), or \"userstyle\".",
+              "description": "The platforms the port supports. Either an array of supported operating systems or \"agnostic\" (indicating support for all platforms).",
               "oneOf": [
                 {
                   "type": "array",
@@ -108,8 +108,7 @@
                 {
                   "type": "string",
                   "enum": [
-                    "agnostic",
-                    "userstyle"
+                    "agnostic"
                   ]
                 }
               ]
@@ -148,16 +147,6 @@
               "examples": [
                 "neovim",
                 "neovim.svg"
-              ]
-            },
-            "userstyle": {
-              "$id": "#ports/port/userstyle",
-              "title": "Userstyle",
-              "description": "Whether the port is a userstyle",
-              "type": "boolean",
-              "examples": [
-                true,
-                false
               ]
             }
           }

--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -983,4 +983,4 @@ showcases:
     - title: Catppuccin Noctis
       description: An alternative to the official VSCode theme, with [Noctis](https://marketplace.visualstudio.com/items?itemName=liviuschera.noctis) syntax highlighting
       link: https://marketplace.visualstudio.com/items?itemName=AlexDauenhauer.catppuccin-noctis
-# yaml-language-server: $schema=ports.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/catppuccin/catppuccin/main/resources/ports.schema.json

--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -21,11 +21,6 @@ ports:
         name: Amfora
         category: leisure
         platform: [linux, macos, windows]
-    anilist:
-        name: AniList
-        category: leisure
-        platform: userstyle
-        color: blue
     anki:
         name: Anki
         category: productivity
@@ -73,12 +68,6 @@ ports:
         name: bottom
         category: cli
         platform: [linux, macos, windows]
-    brave-search:
-        name: Brave Search
-        category: search_engine
-        platform: userstyle
-        icon: brave
-        color: peach
     btop:
         name: Btop++
         category: cli
@@ -98,14 +87,6 @@ ports:
         category: leisure
         platform: [linux, macos, windows]
         color: red
-    cinny:
-        name: Cinny
-        category: messaging
-        platform: userstyle
-    codeberg:
-        name: Codeberg
-        category: productivity
-        platform: userstyle
     codemirror:
         name: CodeMirror
         category: development
@@ -137,10 +118,6 @@ ports:
         platform: agnostic
         icon: darkreader
         color: red
-    deepl:
-        name: DeepL
-        category: productivity
-        platform: userstyle
     discord:
         name: Discord
         category: messaging
@@ -187,10 +164,6 @@ ports:
         name: Element
         category: messaging
         platform: [linux, macos, windows]
-    elk:
-        name: Elk
-        category: social
-        platform: userstyle
     emacs:
         name: Emacs
         category: code_editor
@@ -262,11 +235,6 @@ ports:
         platform: agnostic
         color: green
         icon: gitea
-    github:
-        name: GitHub
-        category: productivity
-        platform: userstyle
-        color: text
     github-readme-stats:
         name: GitHub Readme Stats
         category: social
@@ -307,11 +275,6 @@ ports:
         category: system
         platform: [linux]
         color: green
-    hacker-news:
-        name: Hacker News
-        category: social
-        platform: userstyle
-        icon: ycombinator
     helix:
         name: Helix
         category: code_editor
@@ -350,10 +313,6 @@ ports:
         platform: [linux]
         color: text
         icon: i3wm.svg
-    ichi.moe:
-        name: ichi.moe
-        category: productivity
-        platform: userstyle
     ida-debugger:
         name: IDA (Interactive Disassembler)
         category: code_editor
@@ -374,12 +333,6 @@ ports:
         category: development
         platform: [android]
         color: blue
-    invidious:
-        name: Invidious
-        category: social
-        platform: userstyle
-        icon: youtube
-        color: red
     iterm:
         name: iTerm2
         category: terminal
@@ -439,23 +392,11 @@ ports:
         name: Lapce
         category: code_editor
         platform: [linux, macos, windows]
-    lastfm:
-        name: Last.fm
-        category: leisure
-        platform: userstyle
-        icon: lastdotfm
-        color: red
     lazygit:
         name: Lazygit
         category: cli
         platform: [linux, macos]
         color: green
-    libreddit:
-        name: Libreddit
-        category: social
-        platform: userstyle
-        icon: reddit
-        color: peach
     logseq:
         name: Logseq
         category: note_taking
@@ -485,10 +426,6 @@ ports:
         name: Mako
         category: system
         platform: [linux]
-    mastodon:
-        name: Mastodon
-        category: social
-        platform: userstyle
     matplotlib:
         name: Matplotlib
         category: development
@@ -519,11 +456,6 @@ ports:
         name: Misskey
         category: social
         platform: agnostic
-    modrinth:
-        name: Modrinth
-        category: game
-        platform: userstyle
-        color: green
     monkeytype:
         name: monkeytype
         category: leisure
@@ -559,18 +491,6 @@ ports:
         name: Nilesoft Shell
         category: system
         platform: [windows]
-    nitter:
-        name: Nitter
-        category: social
-        platform: userstyle
-        icon: twitter
-        color: blue
-    nixos-search:
-        name: NixOS Search
-        category: search_engine
-        platform: userstyle
-        icon: nixos
-        color: blue
     noir:
         name: Noir
         category: browser_extension
@@ -651,12 +571,6 @@ ports:
         name: Prism Launcher
         category: game
         platform: [linux, macos, windows]
-    proton:
-        name: Proton
-        category: productivity
-        platform: userstyle
-        icon: protonmail
-        color: lavender
     pyradio:
         name: PyRadio
         category: leisure
@@ -695,12 +609,6 @@ ports:
         platform: [android]
         color: blue
         icon: gboard.svg
-    reddit:
-        name: Reddit
-        category: social
-        platform: userstyle
-        color: red
-        icon: reddit
     refind:
         name: rEFInd
         category: system
@@ -738,10 +646,6 @@ ports:
         name: SDDM
         category: system
         platform: [linux]
-    SearXNG:
-        name: SearXNG
-        category: search_engine
-        platform: userstyle
     sharex:
         name: ShareX
         category: productivity
@@ -870,15 +774,6 @@ ports:
         name: tty
         category: system
         platform: [linux]
-    tutanota:
-        name: Tutanota
-        category: productivity
-        platform: userstyle
-        color: red
-    twitch:
-        name: Twitch
-        category: social
-        platform: userstyle
     tym:
         name: tym
         category: terminal
@@ -911,10 +806,6 @@ ports:
         name: Urxvt
         category: terminal
         platform: [linux]
-    vercel:
-        name: Vercel
-        category: development
-        platform: userstyle
     vim:
         name: Vim
         category: code_editor
@@ -963,11 +854,6 @@ ports:
         name: Whoogle
         category: search_engine
         platform: agnostic
-    wikiwand:
-        name: WikiWand
-        category: productivity
-        platform: userstyle
-        icon: wikipedia
     windows-files:
         name: Windows Files
         category: system
@@ -999,11 +885,6 @@ ports:
         category: system
         platform: [linux]
         icon: xdotorg
-    youtube:
-        name: YouTube
-        category: social
-        platform: userstyle
-        color: red
     youtubemusic:
         name: YouTube Music
         category: leisure
@@ -1098,4 +979,4 @@ showcases:
     - title: Catppuccin Noctis
       description: An alternative to the official VSCode theme, with [Noctis](https://marketplace.visualstudio.com/items?itemName=liviuschera.noctis) syntax highlighting
       link: https://marketplace.visualstudio.com/items?itemName=AlexDauenhauer.catppuccin-noctis
-# yaml-language-server: $schema=https://raw.githubusercontent.com/catppuccin/catppuccin/main/resources/ports.schema.json
+# yaml-language-server: $schema=ports.schema.json


### PR DESCRIPTION
This PR supersedes #1981.

I've updated the documentation to clarify what userstyles are if people are looking to create their own ports, as well as using @rubyowo's existing code to pull in metadata from the https://github.com/catppuccin/userstyles repository to link our userstyles.

It's worth mentioning that the CI hasn't been updated to trigger rebuilds off changes to the userstyles repository as @nekowinston is interested in doing this work. In addition to this, I was experimenting with the mermaid diagram by trying to include the userstyle steps. Unfortunately, it's not formatted well so I've chosen to omit it for now. 

You can see what it currently looks like below:

```mermaid
stateDiagram-v2
  idea: You have an idea for a port
  idea --> choice

  choice: Have you already completed a draft?
  choice --> is_userstyle: Yes
  choice --> request: No

  request: Open a Port Request discussion
  request --> request_picked_up
  
  request_picked_up: You or somebody else works on a draft
  request_picked_up --> request_complete

  request_complete: The draft is completed to your liking
  request_complete --> draft_complete

  is_userstyle: Is this themed via Stylus?
  is_userstyle --> userstyle_review: Yes
  is_userstyle --> draft_complete: No

  userstyle_review: Submit pull request\nto catppuccin/userstyles
  userstyle_review --> review
  
  draft_complete: Create a Port Review issue
  draft_complete --> review

  review: Review period
  review --> port_adoption

  note right of review
    Community feedback
  end note

  port_adoption: Port adoption
```

If this mermaid diagram still seems okay, I'd be happy to include in the docs. Let me know what you think @nekowinston 

