### PR TITLE
✏️ typo(remnote): properly capitalize RemNote's Name

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -622,7 +622,7 @@ ports:
         category: system
         platform: [linux]
     remnote:
-        name: Remnote
+        name: RemNote
         category: note_taking
         platform: agnostic
     replit:


### PR DESCRIPTION
![](https://cdn.betterttv.net/emote/5e95b6fdd023b362f6380e2a/2x.gif) hey!!

I thought for professionalism and consistency, it would be good to capitalize RemNote's name according to their advertising in the main file. 

## Changes 
- `ports.yml`