### PR TITLE
docs: add catppuccin/halloy

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -284,6 +284,10 @@ ports:
         category: system
         platform: [linux]
         color: green
+    halloy:
+        name: Halloy
+        category: messaging
+        platform: [linux, macos, windows]
     helix:
         name: Helix
         category: code_editor


### PR DESCRIPTION
To close https://github.com/catppuccin/catppuccin/issues/2111

Transferred repo: https://github.com/catppuccin/halloy

(Not clear if the `color` and `icon` fields are meant to be used or where they are displayed).