### PR TITLE
Remove Meowix Linux from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1282,7 +1282,6 @@ If you're making an application or tool using our palette, please let us know by
 - [Simple MP](https://github.com/lighttigerXIV/SimpleMP-Compose) - A simple music player based on Material You design
 - [Comfy](https://github.com/Comfy-Themes/Spicetify) - A theme for [Spicetify](https://github.com/spicetify/spicetify-cli) with a basic catppuccin color scheme!
 - [Catppuccin Noctis](https://marketplace.visualstudio.com/items?itemName=AlexDauenhauer.catppuccin-noctis) - An alternative to the official VSCode theme, with [Noctis](https://marketplace.visualstudio.com/items?itemName=liviuschera.noctis) syntax highlighting
-- [Meowix Linux](https://meowix-linux.github.io/) - An Arch Linux-based distribution centered around the Catppuccin theme.
 - [Mind Elixir](https://github.com/ssshooter/mind-elixir-core) - A framework agnostic JavaScript mind map core.
 - [Career Vault](https://careervault.io) - A remote job board that shows hundreds of new opportunities every day.
 <!-- AUTOGEN:SHOWCASE END -->

--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -1142,9 +1142,6 @@ showcases:
     - title: Catppuccin Noctis
       description: An alternative to the official VSCode theme, with [Noctis](https://marketplace.visualstudio.com/items?itemName=liviuschera.noctis) syntax highlighting
       link: https://marketplace.visualstudio.com/items?itemName=AlexDauenhauer.catppuccin-noctis
-    - title: Meowix Linux
-      description: An Arch Linux-based distribution centered around the Catppuccin theme.
-      link: https://meowix-linux.github.io/
     - title: Mind Elixir
       description: A framework agnostic JavaScript mind map core.
       link: https://github.com/ssshooter/mind-elixir-core


### PR DESCRIPTION
Meowix Linux is discontinued, see [here](https://github.com/Meowix-Linux/Meowix-ISO/discussions/11)