### PR TITLE
docs: add catppuccin/simplex

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -769,6 +769,10 @@ ports:
         name: Sidebery
         category: browser_extension
         platform: agnostic
+    simplex:
+        name: SimpleX
+        category: messaging
+        platform: [android]
     skim:
         name: skim
         category: cli


### PR DESCRIPTION
Hi!

Port has been already transferred to the org: [catppuccin/simplex](https://github.com/catppuccin/simplex)
Closes #2144

Thanks in advance!