### PR TITLE
chore(ports.yaml): remove `startpage`

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -838,10 +838,6 @@ ports:
         name: Starship
         category: cli
         platform: [linux, macos, windows]
-    startpage:
-        name: Startpage
-        category: search_engine
-        platform: agnostic
     steam:
         name: Steam
         category: leisure


### PR DESCRIPTION
This is no longer required in the main repository as `catppuccin/userstyles` tracks it.