### PR TITLE
chore: add platform `android` for Yazi

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -1080,7 +1080,7 @@ ports:
     yazi:
         name: Yazi
         category: cli
-        platform: [linux, macos, windows]
+        platform: [android, linux, macos, windows]
         color: peach
     youtubemusic:
         name: YouTube Music


### PR DESCRIPTION
Yazi can be run on Android, https://github.com/termux/termux-packages/blob/master/packages/yazi/build.sh

I added Android to the first position since its first letter is `a` - if this is not the correct order, please let me know, and I'll fix it :)