### PR TITLE
chore(ports.yml): remove `duckduckgo`

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -156,11 +156,6 @@ ports:
         platform: [linux, macos, windows]
         color: red
         icon: racket
-    duckduckgo:
-        name: DuckDuckGo
-        category: search_engine
-        platform: agnostic
-        color: peach
     dunst:
         name: Dunst
         category: system


### PR DESCRIPTION
This is now tracked over at [catppuccin/userstyles](https://github.com/catppuccin/userstyles/blob/331932b2b62dd11d5ad9d0f2a597fdfa84e8831c/scripts/userstyles.yml#L235-L240)