### PR TITLE
docs: update shiki port metadata

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -969,11 +969,11 @@ ports:
         color: blue
         icon: sharex
     shiki:
-        name: ShikiJS
+        name: Shiki
         categories: [development]
         platform: agnostic
         url: https://github.com/catppuccin/vscode/tree/main/packages/catppuccin-vscode
-        color: text
+        color: sapphire
     sidebery:
         name: Sidebery
         categories: [browser_extension]


### PR DESCRIPTION
Updates the name from "ShikiJS" -> "Shiki" and uses a color more in line with the project's branding.