### PR TITLE
chore: update icon & colour for `nix`

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -748,7 +748,8 @@ ports:
         name: Nix
         categories: [system]
         platform: [linux, macos]
-        color: sapphire
+        color: blue
+        icon: nixos
     noir:
         name: Noir
         categories: [browser_extension]


### PR DESCRIPTION
Match the definitions in [catppuccin/userstyles@23b8583/scripts/userstyles.yml#L531-L532](https://github.com/catppuccin/userstyles/blob/23b8583c410e78733476d51e196ae2eb4695adc6/scripts/userstyles.yml#L531-L532)