### PR TITLE
docs: update bat icon and color

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -55,8 +55,8 @@ ports:
         name: bat
         categories: [cli]
         platform: [linux, macos, windows]
-        icon: bat.svg
-        color: sapphire
+        icon: bat
+        color: blue
     bemenu:
         name: bemenu
         categories: [application_launcher, system]


### PR DESCRIPTION
Simple Icons now has an icon for bat included (as of v11.12.0), and looking at the color of their icon in the README and on Simple Icons' website it seems `blue` is more accurate. We may have to make sure Simple Icons is updated in the website repository before merging this? Not sure how that works.