### PR TITLE
feat: track archived ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,7 +1066,6 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 - [Cursors](https://github.com/catppuccin/cursors)
 - [fcitx5](https://github.com/catppuccin/fcitx5)
 - [FlorisBoard](https://github.com/catppuccin/floris-board)
-- [GTK](https://github.com/catppuccin/gtk)
 - [Hyprlock](https://github.com/catppuccin/hyprlock)
 - [Kvantum](https://github.com/catppuccin/Kvantum)
 - [Nilesoft Shell](https://github.com/catppuccin/nilesoft-shell)
@@ -1160,7 +1159,6 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 - [nightTab](https://github.com/catppuccin/nighttab)
 - [Noir](https://github.com/catppuccin/noir)
 - [OldTwitter](https://github.com/catppuccin/oldtwitter)
-- [Sidebery](https://github.com/catppuccin/sidebery)
 - [Vimium](https://github.com/catppuccin/vimium)
 
 </details>
@@ -1312,7 +1310,6 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 <details open>
 <summary>✨ Social Networking</summary>
 
-- [Aliucord](https://github.com/catppuccin/aliucord)
 - [Bluesky Social](https://github.com/catppuccin/userstyles/tree/main/styles/bsky)
 - [Chatterino 2](https://github.com/catppuccin/chatterino2)
 - [Cinny](https://github.com/catppuccin/userstyles/tree/main/styles/cinny)
@@ -1385,7 +1382,6 @@ Catppuccin is available for various apps and in different formats. Here is a lis
 - [Moon Animator 2](https://github.com/catppuccin/moon-animator-2)
 - [Planet Minecraft](https://github.com/catppuccin/userstyles/tree/main/styles/planet-minecraft)
 - [Prism Launcher](https://github.com/catppuccin/prismlauncher)
-- [Steam](https://github.com/catppuccin/steam)
 - [Steam Deck](https://github.com/catppuccin/steam-deck)
 - [ULTRAKILL](https://github.com/catppuccin/ultrakill)
 

--- a/resources/generate/main.ts
+++ b/resources/generate/main.ts
@@ -55,7 +55,7 @@ const ports = {
         type: "userstyle",
       };
       return acc;
-  }, {} as Record<string, MappedPort>),
+    }, {} as Record<string, MappedPort>),
 };
 
 const portSlugs = Object.entries(ports).map(([slug]) => slug);
@@ -89,12 +89,12 @@ const categorized = Object.entries(ports)
         }
       }
 
-       acc[port.categories[0]].push({
+      acc[port.categories[0]].push({
         ...port,
         url,
         name: [port.name].flat().join(", "),
       });
-       acc[port.categories[0]].sort((a, b) =>
+      acc[port.categories[0]].sort((a, b) =>
         [a.name].flat()[0].localeCompare([b.name].flat()[0])
       );
       return acc;

--- a/resources/ports.schema.json
+++ b/resources/ports.schema.json
@@ -35,58 +35,13 @@
           "additionalProperties": false,
           "properties": {
             "name": {
-              "$id": "#ports/port/name",
-              "title": "Name",
-              "description": "The name of the software the port is for.",
-              "type": "string",
-              "examples": [
-                "Neovim"
-              ]
+              "$ref": "#/$defs/port-display-name"
             },
             "categories": {
-              "$id": "#ports/port/categories",
-              "title": "Categories",
-              "description": "The categories that fit the port the most, the first category is the primary category which the port will be listed under on the README.",
-              "$ref": "#/$defs/categories"
+              "$ref": "#/$defs/port-categories"
             },
             "platform": {
-              "$id": "#ports/port/platform",
-              "title": "Platform",
-              "description": "The platforms the port supports. Either an array of supported operating systems or \"agnostic\" (indicating support for all platforms).",
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "$id": "#ports/port/platform/os",
-                    "title": "Operating Systems",
-                    "type": "string",
-                    "enum": [
-                      "android",
-                      "ios",
-                      "linux",
-                      "macos",
-                      "windows"
-                    ],
-                    "examples": [
-                      [
-                        "linux",
-                        "macos",
-                        "windows"
-                      ],
-                      [
-                        "android",
-                        "ios"
-                      ]
-                    ]
-                  }
-                },
-                {
-                  "type": "string",
-                  "enum": [
-                    "agnostic"
-                  ]
-                }
-              ]
+              "$ref": "#/$defs/port-platform"
             },
             "color": {
               "$ref": "#/$defs/color"
@@ -163,6 +118,54 @@
               "minItems": 1,
               "description": "List of all maintainers that have previously maintained this port.",
               "$ref": "#/$defs/collaborators"
+            }
+          }
+        }
+      }
+    },
+    "archived": {
+      "$id": "#archived",
+      "title": "Archived Ports",
+      "description": "All archived ports in the Catppuccin organisation.",
+      "type": "object",
+      "patternProperties": {
+        "[A-Za-z0-9_\\-]": {
+          "$id": "#archived/port/name",
+          "title": "Port",
+          "type": "object",
+          "description": "The GitHub repository name of the archived port.",
+          "examples": [
+            "steam"
+          ],
+          "required": [
+            "name",
+            "reason",
+            "categories",
+            "platform",
+            "color"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "$ref": "#/$defs/port-display-name"
+            },
+            "reason": {
+              "$id": "#/archived/port/reason",
+              "title": "Archive Reason",
+              "description": "A short summary of why the port was archived.",
+              "type": "string"
+            },
+            "categories": {
+              "$ref": "#/$defs/port-categories"
+            },
+            "platform": {
+              "$ref": "#/$defs/port-platform"
+            },
+            "color": {
+              "$ref": "#/$defs/color"
+            },
+            "icon": {
+              "$ref": "#/$defs/icon"
             }
           }
         }
@@ -266,6 +269,60 @@
           "url"
         ]
       }
+    },
+    "port-display-name": {
+      "$id": "#port-display-name",
+      "title": "Name",
+      "description": "The name of the software the port is for.",
+      "type": "string",
+      "examples": [
+        "Neovim"
+      ]
+    },
+    "port-categories": {
+      "$id": "#port-categories",
+      "title": "Categories",
+      "description": "The categories that fit the port the most, the first category is the primary category which the port will be listed under on the README.",
+      "$ref": "#/$defs/categories"
+    },
+    "port-platform": {
+      "$id": "#port-platform",
+      "title": "Platform",
+      "description": "The platforms the port supports. Either an array of supported operating systems or \"agnostic\" (indicating support for all platforms).",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "$id": "#ports/port/platform/os",
+            "title": "Operating Systems",
+            "type": "string",
+            "enum": [
+              "android",
+              "ios",
+              "linux",
+              "macos",
+              "windows"
+            ],
+            "examples": [
+              [
+                "linux",
+                "macos",
+                "windows"
+              ],
+              [
+                "android",
+                "ios"
+              ]
+            ]
+          }
+        },
+        {
+          "type": "string",
+          "enum": [
+            "agnostic"
+          ]
+        }
+      ]
     },
     "icon": {
       "$id": "#icon",

--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -2241,4 +2241,4 @@ showcases:
   - title: Reciper
     description: A simple, open-source recipe management app.
     link: https://github.com/judemont/reciper
-# yaml-language-server: $schema=ports.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/catppuccin/catppuccin/main/resources/ports.schema.json

--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -322,13 +322,6 @@ ports:
     platform: [macos]
     current-maintainers: []
     past-maintainers: [*nekowinston]
-  aliucord:
-    name: Aliucord
-    categories: [social_networking]
-    platform: [android]
-    color: blue
-    icon: discord
-    current-maintainers: [*isabelincorp]
   amfora:
     name: Amfora
     categories: [entertainment]
@@ -833,13 +826,6 @@ ports:
     color: text
     current-maintainers: [*isabelincorp]
     past-maintainers: [*elkrien]
-  gtk:
-    name: GTK
-    categories: [system]
-    platform: [linux]
-    color: green
-    icon: gtk
-    current-maintainers: [*rubyowo, *Syndrizzle]
   halloy:
     name: Halloy
     categories: [social_networking]
@@ -1559,12 +1545,6 @@ ports:
     color: sapphire
     current-maintainers: []
     past-maintainers: [*nekowinston]
-  sidebery:
-    name: Sidebery
-    categories: [browser_extension]
-    platform: agnostic
-    color: text
-    current-maintainers: []
   simplex:
     name: SimpleX
     categories: [social_networking]
@@ -1660,13 +1640,6 @@ ports:
     color: pink
     icon: starship
     current-maintainers: [*JoshPaulie]
-  steam:
-    name: Steam
-    categories: [game, application_launcher, entertainment]
-    platform: [linux, macos, windows]
-    color: text
-    icon: steam
-    current-maintainers: []
   steam-deck:
     name: Steam Deck
     categories: [game, entertainment]
@@ -2074,6 +2047,35 @@ ports:
     color: text
     current-maintainers: [*sakkke]
 
+archived:
+  aliucord:
+    name: Aliucord
+    reason: "Maintainer thought the upstream project was unmaintained, this port could be revived again."
+    categories: [social_networking]
+    platform: [android]
+    color: blue
+    icon: discord
+  gtk:
+    name: GTK
+    reason: "Incredibly difficult to theme and maintain, this port could be revived if better theming methods arise. (highly unlikely)"
+    categories: [system]
+    platform: [linux]
+    color: green
+    icon: gtk
+  sidebery:
+    name: Sidebery
+    reason: "Sidebery automatically takes in colours from the Firefox theme, this port is now redundant."
+    categories: [browser_extension]
+    platform: agnostic
+    color: text
+  steam:
+    name: Steam
+    reason: "Incredibly difficult to theme and maintain, this port could be revived if better theming methods arise. (highly unlikely)"
+    categories: [game, application_launcher, entertainment]
+    platform: [linux, macos, windows]
+    color: text
+    icon: steam
+
 categories:
   - key: code_editor
     name: Code Editors & IDEs
@@ -2239,4 +2241,4 @@ showcases:
   - title: Reciper
     description: A simple, open-source recipe management app.
     link: https://github.com/judemont/reciper
-# yaml-language-server: $schema=https://raw.githubusercontent.com/catppuccin/catppuccin/main/resources/ports.schema.json
+# yaml-language-server: $schema=ports.schema.json

--- a/resources/types/ports.d.ts
+++ b/resources/types/ports.d.ts
@@ -148,6 +148,10 @@ export type PastMaintainers = [
     [k: string]: unknown;
   }[]
 ];
+/**
+ * A short summary of why the port was archived.
+ */
+export type ArchiveReason = string;
 export type Key =
   | "3d_modelling"
   | "analytics"
@@ -202,6 +206,7 @@ export type Showcases = ShowcaseItem[];
 export interface PortsSchema {
   collaborators?: AllCollaborators;
   ports?: Ports;
+  archived?: ArchivedPorts;
   categories?: CategoryDefinitions;
   showcases?: Showcases;
 }
@@ -235,6 +240,26 @@ export interface Link {
   color?: Color;
   icon?: Icon;
   url: URL1;
+}
+/**
+ * All archived ports in the Catppuccin organisation.
+ */
+export interface ArchivedPorts {
+  [k: string]: Port1;
+}
+/**
+ * The GitHub repository name of the archived port.
+ *
+ * This interface was referenced by `ArchivedPorts`'s JSON-Schema definition
+ * via the `patternProperty` "[A-Za-z0-9_\-]".
+ */
+export interface Port1 {
+  name: Name;
+  reason: ArchiveReason;
+  categories: Categories;
+  platform: Platform;
+  color: Color;
+  icon?: Icon;
 }
 export interface CategoryItem {
   key: Key;


### PR DESCRIPTION
Closes #2409 

Outstanding questions:

- Do we want to display the archived repositories on the README in this repository? The future goal is to point everyone to our website so I didn't bother touching the deno code.
- I thought about adding an `archive_kind` enum but just opted for a simple string to track the reasoning, maybe worth revisiting.