### PR TITLE
chore(ports.yml): update anki & rime icons

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -347,7 +347,7 @@ ports:
     name: Anki
     categories: [education, productivity]
     platform: agnostic
-    icon: anki.svg
+    icon: anki
     color: blue
     current-maintainers: [*AnubisNekhet]
     past-maintainers: [*BlueFalconHD]
@@ -1668,6 +1668,7 @@ ports:
     categories: [productivity]
     platform: [macos]
     color: text
+    icon: rime
     current-maintainers: [*moseeking]
   st:
     name: st


### PR DESCRIPTION
Adds an icon for Squirrel/Rime and uses the upstream Anki icon instead of our custom one.