### PR TITLE
chore(ports.yml): add suckless icon for dmenu

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -580,6 +580,7 @@ ports:
     categories: [application_launcher, system]
     platform: [linux]
     color: sapphire
+    icon: suckless
     current-maintainers: []
     past-maintainers: [*ohxxm]
   dopamine:


### PR DESCRIPTION
We already use the parent organization of suckless's icon for `st`, one of their projects, so it makes sense to also do it for `dmenu`, another one of theirs. #2447 should also be added with the suckless icon.