### PR TITLE
chore: re-add `Catppuccin Noctis Icons` to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1434,12 +1434,13 @@ If you're making an application or tool using our palette, please let us know by
 
 <!-- AUTOGEN:SHOWCASE START -->
 <!-- the following section is auto-generated, do not edit -->
-- [flotes.app](https://flotes.app/) - A free note-taking app enhanced with flashcard features
-- [AnuPpuccin](https://github.com/AnubisNekhet/AnuPpuccin) - Highly customizable theme for [Obsidian](https://obsidian.md)
-- [faerber](https://farbenfroh.io/faerber) - Website for applying custom color schemes to any wallpaper
-- [Simple MP](https://github.com/lighttigerXIV/SimpleMP-Compose) - A simple music player based on Material You design
+- [flotes.app](https://flotes.app/) - A free note-taking app enhanced with flashcard features.
+- [AnuPpuccin](https://github.com/AnubisNekhet/AnuPpuccin) - Highly customizable theme for [Obsidian](https://obsidian.md).
+- [faerber](https://farbenfroh.io/faerber) - Website for applying custom color schemes to any wallpaper.
+- [Simple MP](https://github.com/lighttigerXIV/SimpleMP-Compose) - A simple music player based on Material You design.
 - [Comfy](https://github.com/Comfy-Themes/Spicetify) - A theme for [Spicetify](https://github.com/spicetify/spicetify-cli) with a basic catppuccin color scheme!
-- [Catppuccin Noctis](https://marketplace.visualstudio.com/items?itemName=AlexDauenhauer.catppuccin-noctis) - An alternative to the official VSCode theme, with [Noctis](https://marketplace.visualstudio.com/items?itemName=liviuschera.noctis) syntax highlighting
+- [Catppuccin Noctis](https://marketplace.visualstudio.com/items?itemName=AlexDauenhauer.catppuccin-noctis) - An alternative to the official VSCode theme, with [Noctis](https://marketplace.visualstudio.com/items?itemName=liviuschera.noctis) syntax highlighting.
+- [Catppuccin Noctis Icons](https://marketplace.visualstudio.com/items?itemName=AlexDauenhauer.catppuccin-noctis-icons) - A companion icons theme for Catppuccin Noctis color theme. Forked from [Symbols Icon Theme](https://github.com/miguelsolorio/vscode-symbols).
 - [Mind Elixir](https://github.com/ssshooter/mind-elixir-core) - A framework agnostic JavaScript mind map core.
 - [Career Vault](https://careervault.io) - A remote job board that shows hundreds of new opportunities every day.
 - [Loungy](https://loungy.app) - An open-source application launcher in the vein of Raycast and Alfred.

--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -2286,23 +2286,26 @@ categories:
 
 showcases:
   - title: flotes.app
-    description: A free note-taking app enhanced with flashcard features
+    description: A free note-taking app enhanced with flashcard features.
     link: https://flotes.app/
   - title: AnuPpuccin
-    description: Highly customizable theme for [Obsidian](https://obsidian.md)
+    description: Highly customizable theme for [Obsidian](https://obsidian.md).
     link: https://github.com/AnubisNekhet/AnuPpuccin
   - title: faerber
-    description: Website for applying custom color schemes to any wallpaper
+    description: Website for applying custom color schemes to any wallpaper.
     link: https://farbenfroh.io/faerber
   - title: Simple MP
-    description: A simple music player based on Material You design
+    description: A simple music player based on Material You design.
     link: https://github.com/lighttigerXIV/SimpleMP-Compose
   - title: Comfy
     description: A theme for [Spicetify](https://github.com/spicetify/spicetify-cli) with a basic catppuccin color scheme!
     link: https://github.com/Comfy-Themes/Spicetify
   - title: Catppuccin Noctis
-    description: An alternative to the official VSCode theme, with [Noctis](https://marketplace.visualstudio.com/items?itemName=liviuschera.noctis) syntax highlighting
+    description: An alternative to the official VSCode theme, with [Noctis](https://marketplace.visualstudio.com/items?itemName=liviuschera.noctis) syntax highlighting.
     link: https://marketplace.visualstudio.com/items?itemName=AlexDauenhauer.catppuccin-noctis
+  - title: Catppuccin Noctis Icons
+    description: A companion icons theme for Catppuccin Noctis color theme. Forked from [Symbols Icon Theme](https://github.com/miguelsolorio/vscode-symbols).
+    link: https://marketplace.visualstudio.com/items?itemName=AlexDauenhauer.catppuccin-noctis-icons
   - title: Mind Elixir
     description: A framework agnostic JavaScript mind map core.
     link: https://github.com/ssshooter/mind-elixir-core


### PR DESCRIPTION
This was unintentionally removed as the extension
wasn't added to the showcases section within the
ports.yml file.
