### PR TITLE
docs: alias/archive catppuccin/matplotlib

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -1191,7 +1191,9 @@ ports:
     categories: [development, analytics]
     platform: agnostic
     color: blue
-    current-maintainers: [*brambozz]
+    alias: python
+    current-maintainers: [*backwardspy]
+    past-maintainers: [*brambozz] # TBC
   mattermost:
     name: Mattermost
     categories: [social_networking]
@@ -2135,6 +2137,12 @@ archived:
     platform: [linux]
     color: green
     icon: gtk
+  matplotlib:
+    name: Matplotlib
+    reason: "The package is now included within catppuccin/python, therefore the catppuccin/matplotlib repository has been archived."
+    categories: [development, analytics]
+    platform: agnostic
+    color: blue
   oldtwitter:
     name: OldTwitter
     reason: "Extension is unusable due to X/Twitter's extensive measures to limit third party modifications, this port could be revived."

--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -1192,8 +1192,7 @@ ports:
     platform: agnostic
     color: blue
     alias: python
-    current-maintainers: [*backwardspy]
-    past-maintainers: [*brambozz] # TBC
+    current-maintainers: [*backwardspy, *brambozz]
   mattermost:
     name: Mattermost
     categories: [social_networking]


### PR DESCRIPTION
This package is now included within catppuccin/python,
therefore the catppuccin/matplotlib repository has
been archived.
