### PR TITLE
docs(CONTRIBUTING): prepend `https://` to link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ changes to this document in a pull request.
 
 ## Recommendations
 
-- Create a [topic branch](https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows) on your fork for your
+- Create a [topic branch](https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows#_topic_branch) on your fork for your
   specific PR. 
 - Consider using [conventionalcommits.org](https://www.conventionalcommits.org/en/v1.0.0/)'s rules for creating explicit
   and meaningful commit messages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ changes to this document in a pull request.
 
 ## Recommendations
 
-- Create a [topic branch](git-scm.com/book/en/v2/Git-Branching-Branching-Workflows#_topic_branch) on your fork for your
+- Create a [topic branch](https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows) on your fork for your
   specific PR. 
 - Consider using [conventionalcommits.org](https://www.conventionalcommits.org/en/v1.0.0/)'s rules for creating explicit
   and meaningful commit messages.


### PR DESCRIPTION
## 🔧 What does this fix? 🔧
fixes a link thats going to a folder (or a branch) that doesn't exist anymore