### PR TITLE
fix(categories): ensure all emojis have `Variation Selector-16`

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -2265,7 +2265,7 @@ categories:
   - key: desktop_environment
     name: Desktop Environments
     description: Graphical User Interfaces providing a complete experience for interacting with the operating system.
-    emoji: 🖥
+    emoji: 🖥️
   - key: window_manager
     name: Window Managers
     description: Applications that control the placement and appearance of windows in a GUI.
@@ -2277,7 +2277,7 @@ categories:
   - key: application_launcher
     name: Application Launchers
     description: Tools that provide a quick and easy way for users to launch applications.
-    emoji: 🗃
+    emoji: 🗃️
   - key: browser
     name: Browsers
     description: Applications for accessing and navigating the World Wide Web.
@@ -2317,7 +2317,7 @@ categories:
   - key: game_development
     name: Game Development
     description: Applications that are designed for creating, designing and building video games.
-    emoji: 🕹
+    emoji: 🕹️
   - key: 3d_modelling
     name: 3D Modelling
     description: Applications that are designed to create and manipulate objects in three-dimensional space.


### PR DESCRIPTION
some emojis require having `Variation Selector-16` to be rendered correctly (on my device at least)

from [wikipedia](https://en.wikipedia.org/wiki/Variation_Selectors_(Unicode_block)):
> VS15 and VS16 are reserved to request that a character should be displayed as text or as an [emoji](https://en.wikipedia.org/wiki/Emoji) respectively.

for example this is how `🕹 🕹️` appears for me
![image](https://github.com/user-attachments/assets/db528107-928c-45bb-a0e4-613c6ce30fb9)
the first one is [just a joystick](https://apps.timwhitlock.info/unicode/inspect?s=%F0%9F%95%B9) but the second one [contains `Variation Selector-16`](https://apps.timwhitlock.info/unicode/inspect?s=%F0%9F%95%B9%EF%B8%8F)

this is probably required for all emojis listed [here](https://www.unicode.org/emoji/charts/emoji-variants.html)

some emojis in ports.yml weren't being rendered correctly for me so i replaced them with working versions
fun fact: this is already applied to some emojis in the file (🗂️ 🗺️🖼️🗣️)
related: [Automatically add ️`Variation Selector-16` for emoji unicode input · Issue \#2139 · kovidgoyal/kitty · GitHub](https://github.com/kovidgoyal/kitty/issues/2139)