### PR TITLE
chore(nvim): move `mrtnvgr` to past-maintainers

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -1431,8 +1431,8 @@ ports:
     platform: [linux, macos, windows]
     icon: neovim
     color: green
-    current-maintainers: [*mrtnvgr, *vollowx]
-    past-maintainers: [*pocco81, *nullchilly]
+    current-maintainers: [*vollowx]
+    past-maintainers: [*pocco81, *nullchilly, *mrtnvgr]
   obs:
     name: OBS Studio
     categories: [productivity, photo_and_video]


### PR DESCRIPTION

This person reached out and let me know that they are no longer interested in
maintaining the nvim port.

Thanks to them for all their work on it!
