### PR TITLE
chore(codemirror): remove @uncenter from current-maintainers

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -543,7 +543,7 @@ ports:
     color: red
     icon: codemirror
     platform: agnostic
-    current-maintainers: [*uncenter]
+    current-maintainers: []
     past-maintainers: [*griimick]
   conky:
     name: Conky


### PR DESCRIPTION
As mentioned in https://github.com/catppuccin/codemirror/pull/6.