### PR TITLE
docs(showcase): add catppuccin startpage

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -2557,4 +2557,7 @@ showcases:
   - title: Tomatillo Timer
     description: A modern pomodoro timer that syncs to your music
     link: https://timer.flotes.app/?theme=mocha
+  - title: Catppuccin Startpage
+    description: Aesthetic and clean startpage in Catppuccin style, hosted on GitHub Pages
+    link: https://github.com/pivoshenko/catppuccin-startpage
 # yaml-language-server: $schema=https://raw.githubusercontent.com/catppuccin/catppuccin/main/resources/ports.schema.json


### PR DESCRIPTION
@pivoshenko i've used the github repo as the link instead of the hosted preview as i expect more people would want to go to the repo first to see how to customise it et cetera. please let me know if you'd prefer it to link to https://pivoshenko.github.io/catppuccin-startpage instead!

closes #2662