### PR TITLE
docs: rename github-file-explorer-icons to web-file-explorer-icons

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -896,12 +896,11 @@ ports:
     icon: gitea
     current-maintainers: [*sgoudham]
     past-maintainers: [*nekowinston]
-  github-file-explorer-icons:
-    name: GitHub File Explorer Icons
+  web-file-explorer-icons:
+    name: Web File Explorer Icons
     categories: [browser_extension]
     platform: [agnostic]
     color: text
-    icon: github
     current-maintainers: [*uncenter]
   github-readme-stats:
     name: GitHub Readme Stats


### PR DESCRIPTION
Part of https://github.com/catppuccin/github-file-explorer-icons/issues/109. Will need to rename repository too.