### PR TITLE
chore(kde): move @Sourcastic to `past-maintainers`

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -1197,8 +1197,8 @@ ports:
     platform: [linux]
     color: blue
     icon: kde
-    current-maintainers: [*Sourcastic]
-    past-maintainers: [*Prayag2]
+    current-maintainers: []
+    past-maintainers: [*Prayag2, *Sourcastic]
   kicad:
     name: KiCad
     platform: [linux, macos, windows]


### PR DESCRIPTION
Hey @Sourcastic 👋,

I noticed that you haven't been able to dedicate time to Catppuccin (which is fine!) but I think it makes sense to deem KDE as unmaintained.

I'll merge as is but feel free to reach out afterwards in this PR or in discord if you want to chat more. 