### PR TITLE
docs(showcase): add ccrs

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -2512,4 +2512,7 @@ showcases:
   - title: Catppuccin Startpage
     description: Aesthetic and clean startpage in Catppuccin style, hosted on GitHub Pages
     link: https://github.com/pivoshenko/catppuccin-startpage
+  - title: ccrs
+    description: A simple yet highly configurable set of widgets for Rainmeter.
+    link: https://github.com/336conaN/ccrs
 # yaml-language-server: $schema=./ports.schema.json


### PR DESCRIPTION
# 🚀 Description
A simple yet highly configurable set of widgets for Rainmeter, featuring 18 widgets and 14 themes (including all Catppuccin flavors). Unlike many other skins, the entire configuration is handled through a single `settings.inc` file, designed to be as clean and minimalistic as possible.

# 🖼️ Showcase
![preview](https://github.com/user-attachments/assets/c7484ec1-4de7-4269-8bfa-bfab6d443461)