### PR TITLE
feat: define on accent colour

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -146,6 +146,16 @@
     </td>
   </tr>
   <tr>
+    <td>On Accent</td>
+    <td>Base</td>
+    <td>
+      <img src="../assets/palette/circles/latte_base.png" height="15" width="16"/>
+      <img src="../assets/palette/circles/frappe_base.png" height="15" width="16"/>
+      <img src="../assets/palette/circles/macchiato_base.png" height="15" width="16"/>
+      <img src="../assets/palette/circles/mocha_base.png" height="15" width="16"/>
+    </td>
+  </tr>
+  <tr>
     <td>Links, URLs</td>
     <td>Blue</td>
     <td>


### PR DESCRIPTION
Closes #2836

Defines what colour should go on top of accents in the style guide (rosewater, mauve, green...)