### PR TITLE
Define Units as Yellow in the style guide

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -791,7 +791,7 @@ The color values for `black` and `white` are mapped as shown below:
           <td>
             Classes, Interfaces,<br>
             Annotations, Metadata,<br>
-            Enums, Types
+            Enums, Types, Units
           </td>
           <td>Yellow</td>
           <td>


### PR DESCRIPTION
Colors for units in languages that support them is inconsistent, as there's no definition for them in the style guide.

<img width="254" height="376" alt="image" src="https://github.com/user-attachments/assets/d35cadd7-3ce6-473b-a476-f1921ff905d8" />


I propose to define them as Yellow, same as types. For example, I would expect that the `usize` in the below picture is the same color on both lines:

<img width="149" height="81" alt="image" src="https://github.com/user-attachments/assets/3b193942-3b6b-4d03-9840-6046053b2bc8" />

Yellow units look like this:

<img width="571" height="437" alt="image" src="https://github.com/user-attachments/assets/96fd1eef-05fc-41cd-99b1-e9b9ea6836a7" />
