### PR TITLE
docs(showcase): Add UTM parameters to n-recipe link

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -2508,7 +2508,7 @@ showcases:
     link: https://github.com/a3chron/gith
   - title: n-recipe
     description: Recipe book for Android with Catppuccin & Material You themes
-    link: https://play.google.com/store/apps/details?id=com.a3chron.nrecipe
+    link: https://play.google.com/store/apps/details?id=com.a3chron.nrecipe&utm_source=catppuccin
   - title: Bookbank
     description: A self-hosted audiobook and podcast media server.
     link: https://github.com/alwaysnur/bookbank


### PR DESCRIPTION
Hi, sorry that I add this now, and not with initially adding n-recipe :|
Just want a little insight on where my installs are coming from :relaxed: 