### PR TITLE
docs: add catppuccin/gemini-cli

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -196,6 +196,7 @@ collaborators:
   - &VictorTennekes VictorTennekes
   - &vollowx vollowx
   - &walshyb walshyb
+  - &WalkQuackBack WalkQuackBack
   - &Waxxx333 Waxxx333
   - &WitherCubes WitherCubes
   - &maemachinebroke maemachinebroke
@@ -732,6 +733,13 @@ ports:
     platform: [linux]
     color: text
     current-maintainers: []
+  gemini-cli:
+    name: Gemini CLI
+    categories: [artificial_intelligence, cli]
+    platform: [linux, macos, windows]
+    color: mauve
+    icon: googlegemini
+    current-maintainers: [*WalkQuackBack]
   gh-dash:
     name: gh-dash
     categories: [productivity]


### PR DESCRIPTION
Add the metadata for the Gemini CLI port.
Closes #2919 