### PR TITLE
docs(showcase): add Catppuccin Palette Picker extension

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -2521,4 +2521,7 @@ showcases:
   - title: Bookbank
     description: A self-hosted audiobook and podcast media server.
     link: https://github.com/alwaysnur/bookbank
+  - title: Catppuccin Palette Picker
+    description: A VS Code extension to easily reference and copy Catppuccin colors directly from the editor.
+    link: https://github.com/lily-gh/catppuccin-palette-picker
 # yaml-language-server: $schema=./ports.schema.json


### PR DESCRIPTION
Hi there. I made an extension to help me reference and copy Catppuccin Colors when styling other apps in VS Code / VS Codium.

I hope it can be useful for others too.