### PR TITLE
docs: add catppuccin/plugdata

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -1501,7 +1501,7 @@ ports:
     name: PlugData
     categories: [productivity]
     platform: [windows, macos, linux]
-    color: sapphire
+    color: blue
     current-maintainers: [*scarcekoi]
   plymouth:
     name: Plymouth


### PR DESCRIPTION
Adds PlugData to ports.yml.
Closes #2970.
Will close if #2970 is closed (and it's not added as an official port).
(This should be squashed and merged.)