### PR TITLE
chore(ports): update icons

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -257,7 +257,7 @@ ports:
   asciinema:
     name: Asciinema
     categories: [cli, productivity, development]
-    color: text
+    color: red
     icon: asciinema
     platform: [linux, macos, windows]
     current-maintainers: [*0komo]


### PR DESCRIPTION
Add icons for Cider (Apple Music icon), FreshRSS, Ghostty, Helix, Heroic, mpv, and SimpleX.
Re-orders every port so icon is right after color (visual difference, not really important).