### PR TITLE
chore(kde): add Xerrion as maintainer

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -204,6 +204,7 @@ collaborators:
   - &WitherCubes WitherCubes
   - &maemachinebroke maemachinebroke
   - &xhayper xhayper
+  - &Xerrion Xerrion
   - &Xurdejl Xurdejl
   - &Zazucki Zazucki
   - &zspher zspher
@@ -1105,7 +1106,7 @@ ports:
     platform: [linux]
     color: blue
     icon: kde
-    current-maintainers: []
+    current-maintainers: [*Xerrion]
     past-maintainers: [*Prayag2, *Sourcastic]
   keybr:
     name: keybr.com


### PR DESCRIPTION
## Summary

- Add myself as maintainer for the KDE port, which currently has no active maintainers.
- I have been actively working on fixes and features for `catppuccin/kde`:
  - [PR #109](https://github.com/catppuccin/kde/pull/109) - 20 bug fixes across the installer
  - [PR #110](https://github.com/catppuccin/kde/pull/110) - New colors-only Plasma Style (desktop theme)
  - [PR #111](https://github.com/catppuccin/kde/pull/111) - Fix global theme not appearing in KDE settings (catppuccin/kde#96)