### PR TITLE
docs(showcase): add Yaw Terminal

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -2529,4 +2529,7 @@ showcases:
   - title: Bookbank
     description: A self-hosted audiobook and podcast media server.
     link: https://github.com/alwaysnur/bookbank
+  - title: Yaw
+    description: A modern SSH terminal with Catppuccin Mocha as its default theme.
+    link: https://yaw.sh
 # yaml-language-server: $schema=./ports.schema.json


### PR DESCRIPTION
Add [Yaw](https://yaw.sh) to the showcase section. Yaw is a modern SSH terminal that uses Catppuccin Mocha as its default theme throughout the entire UI.