### PR TITLE
feat(showcase): add Thoth Tarot Handbook

### DIFF
--- a/resources/ports.yml
+++ b/resources/ports.yml
@@ -2529,6 +2529,9 @@ archived:
     icon: steam
 
 showcases:
+  - title: Thoth Tarot Handbook
+    description: An interactive, open-source encyclopedia of the Thoth Tarot — cards, Tree of Life, and astrology cross-linked.
+    link: https://toth.jakub.computer
   - title: flotes.app
     description: A free note-taking app enhanced with flashcard features.
     link: https://flotes.app/


### PR DESCRIPTION
Adds the Thoth Tarot Handbook to the Showcase — a free, open-source web encyclopedia of the Thoth Tarot system, with the Tree of Life and astrology cross-linked. Three Catppuccin flavors are implemented across the entire UI (Mocha / Macchiato / Frappe), switchable from the Settings panel.

Live: https://toth.jakub.computer
Repo: https://github.com/ctrlaltjakub/Toth-Tarot-Handbook